### PR TITLE
Rename CachedSatisfaction to Component

### DIFF
--- a/src/main/java/org/grouplens/grapht/CachePolicy.java
+++ b/src/main/java/org/grouplens/grapht/CachePolicy.java
@@ -16,7 +16,7 @@
  * this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package org.grouplens.grapht.reflect;
+package org.grouplens.grapht;
 
 public enum CachePolicy {
     /**

--- a/src/main/java/org/grouplens/grapht/Component.java
+++ b/src/main/java/org/grouplens/grapht/Component.java
@@ -16,54 +16,46 @@
  * this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package org.grouplens.grapht.reflect;
+package org.grouplens.grapht;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.grouplens.grapht.reflect.Satisfaction;
 import org.grouplens.grapht.util.Preconditions;
 
 import java.io.Serializable;
 
 /**
- * CachedSatisfaction is the pairing of a {@link Satisfaction} and
- * {@link CachePolicy}. Satisfaction cannot specify its own cache policy because
- * the policy is dependent on the edges and bindings taken to reach a particular
- * node in the graph.
- * 
+ * A component to be instantiated in the final dependency plan.  A component consists of a {@link
+ * Satisfaction} and related information for instantiating it (such as the {@link CachePolicy}).
+ *
  * @author <a href="http://grouplens.org">GroupLens Research</a>
  */
-public class CachedSatisfaction implements Serializable {
+public class Component implements Serializable {
     private static final long serialVersionUID = 5L;
     
     private final Satisfaction satisfaction;
     private final CachePolicy cachePolicy;
 
-    /**
-     * Create a new CachedSatisfaction wrapping the given satisfaction and the
-     * satisfaction's default cache policy.
-     * 
-     * @param satisfaction The satisfaction to wrap
-     * @throws NullPointerException if satisfaction is null
-     */
-    public CachedSatisfaction(Satisfaction satisfaction) {
-        this(satisfaction, satisfaction.getDefaultCachePolicy());
-    }
-
-    /**
-     * Create a new CachedSatisfaction wrapping the given satisfaction and cache policy. Providers
-     * from the given satisfaction, used in conjunction with this pair, must be wrapped to satisfy
-     * the chosen policy.
-     *
-     * @param satisfaction The satisfaction to wrap
-     * @param policy       The policy used with this satisfaction
-     * @throws NullPointerException the satisfaction or policy is null
-     */
-    public CachedSatisfaction(Satisfaction satisfaction, CachePolicy policy) {
+    private Component(Satisfaction satisfaction, CachePolicy policy) {
         Preconditions.notNull("satisfaction", satisfaction);
         Preconditions.notNull("policy", policy);
 
         this.satisfaction = satisfaction;
         cachePolicy = policy;
+    }
+
+    /**
+     * Create a new Component wrapping the given satisfaction and cache policy.  The injector is
+     * responsible for using the satisfaction to implement this component consistent with its
+     * cache policy.
+     *
+     * @param satisfaction The satisfaction to wrap
+     * @param policy       The policy used with this satisfaction
+     * @throws NullPointerException the satisfaction or policy is null
+     */
+    public static Component create(Satisfaction satisfaction, CachePolicy policy) {
+        return new Component(satisfaction, policy);
     }
 
     /**
@@ -83,11 +75,11 @@ public class CachedSatisfaction implements Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof CachedSatisfaction)) {
+        if (!(o instanceof Component)) {
             return false;
         }
             
-        CachedSatisfaction c = (CachedSatisfaction) o;
+        Component c = (Component) o;
         EqualsBuilder eqb = new EqualsBuilder();
         return eqb.append(satisfaction, c.satisfaction)
                   .append(cachePolicy, c.cachePolicy)

--- a/src/main/java/org/grouplens/grapht/InjectorBuilder.java
+++ b/src/main/java/org/grouplens/grapht/InjectorBuilder.java
@@ -23,7 +23,6 @@ import org.grouplens.grapht.solver.BindingFunction;
 import org.grouplens.grapht.solver.DefaultDesireBindingFunction;
 import org.grouplens.grapht.solver.DefaultInjector;
 import org.grouplens.grapht.solver.ProviderBindingFunction;
-import org.grouplens.grapht.reflect.CachePolicy;
 import org.grouplens.grapht.context.ContextPattern;
 import org.grouplens.grapht.util.Types;
 

--- a/src/main/java/org/grouplens/grapht/reflect/Satisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/Satisfaction.java
@@ -18,6 +18,7 @@
  */
 package org.grouplens.grapht.reflect;
 
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.Injector;
 
 import javax.inject.Provider;

--- a/src/main/java/org/grouplens/grapht/reflect/internal/ClassSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/ClassSatisfaction.java
@@ -18,6 +18,7 @@
  */
 package org.grouplens.grapht.reflect.internal;
 
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.*;
 import org.grouplens.grapht.util.ClassProxy;
 import org.grouplens.grapht.util.Preconditions;

--- a/src/main/java/org/grouplens/grapht/reflect/internal/InstanceSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/InstanceSatisfaction.java
@@ -18,6 +18,7 @@
  */
 package org.grouplens.grapht.reflect.internal;
 
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.*;
 import org.grouplens.grapht.util.InstanceProvider;
 import org.grouplens.grapht.util.Preconditions;

--- a/src/main/java/org/grouplens/grapht/reflect/internal/NullSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/NullSatisfaction.java
@@ -18,6 +18,7 @@
  */
 package org.grouplens.grapht.reflect.internal;
 
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.*;
 import org.grouplens.grapht.util.ClassProxy;
 import org.grouplens.grapht.util.InstanceProvider;

--- a/src/main/java/org/grouplens/grapht/reflect/internal/ProviderClassSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/ProviderClassSatisfaction.java
@@ -18,6 +18,7 @@
  */
 package org.grouplens.grapht.reflect.internal;
 
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.*;
 import org.grouplens.grapht.util.ClassProxy;
 import org.grouplens.grapht.util.Preconditions;

--- a/src/main/java/org/grouplens/grapht/reflect/internal/ProviderInstanceSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/ProviderInstanceSatisfaction.java
@@ -18,6 +18,7 @@
  */
 package org.grouplens.grapht.reflect.internal;
 
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.*;
 import org.grouplens.grapht.util.Preconditions;
 import org.grouplens.grapht.util.Types;

--- a/src/main/java/org/grouplens/grapht/solver/BindRule.java
+++ b/src/main/java/org/grouplens/grapht/solver/BindRule.java
@@ -18,7 +18,7 @@
  */
 package org.grouplens.grapht.solver;
 
-import org.grouplens.grapht.reflect.CachePolicy;
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.Desire;
 
 import java.util.EnumSet;

--- a/src/main/java/org/grouplens/grapht/solver/BindRuleBuilder.java
+++ b/src/main/java/org/grouplens/grapht/solver/BindRuleBuilder.java
@@ -19,7 +19,7 @@
 package org.grouplens.grapht.solver;
 
 import com.google.common.base.Preconditions;
-import org.grouplens.grapht.reflect.CachePolicy;
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.QualifierMatcher;
 import org.grouplens.grapht.reflect.Qualifiers;
 import org.grouplens.grapht.reflect.Satisfaction;

--- a/src/main/java/org/grouplens/grapht/solver/BindRuleImpl.java
+++ b/src/main/java/org/grouplens/grapht/solver/BindRuleImpl.java
@@ -20,7 +20,7 @@ package org.grouplens.grapht.solver;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.grouplens.grapht.reflect.CachePolicy;
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.Desire;
 import org.grouplens.grapht.reflect.QualifierMatcher;
 import org.grouplens.grapht.reflect.Satisfaction;

--- a/src/main/java/org/grouplens/grapht/solver/BindRules.java
+++ b/src/main/java/org/grouplens/grapht/solver/BindRules.java
@@ -18,7 +18,7 @@
  */
 package org.grouplens.grapht.solver;
 
-import org.grouplens.grapht.reflect.CachePolicy;
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.QualifierMatcher;
 import org.grouplens.grapht.reflect.Satisfaction;
 

--- a/src/main/java/org/grouplens/grapht/solver/BindingResult.java
+++ b/src/main/java/org/grouplens/grapht/solver/BindingResult.java
@@ -18,7 +18,7 @@
  */
 package org.grouplens.grapht.solver;
 
-import org.grouplens.grapht.reflect.CachePolicy;
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.Desire;
 import org.grouplens.grapht.util.Preconditions;
 

--- a/src/main/java/org/grouplens/grapht/solver/DefaultDesireBindingFunction.java
+++ b/src/main/java/org/grouplens/grapht/solver/DefaultDesireBindingFunction.java
@@ -19,7 +19,7 @@
 package org.grouplens.grapht.solver;
 
 import org.grouplens.grapht.annotation.*;
-import org.grouplens.grapht.reflect.CachePolicy;
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.Desire;
 import org.grouplens.grapht.reflect.Satisfaction;
 import org.grouplens.grapht.reflect.Satisfactions;

--- a/src/main/java/org/grouplens/grapht/solver/DependencySolverBuilder.java
+++ b/src/main/java/org/grouplens/grapht/solver/DependencySolverBuilder.java
@@ -18,7 +18,7 @@
  */
 package org.grouplens.grapht.solver;
 
-import org.grouplens.grapht.reflect.CachePolicy;
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.util.Preconditions;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/org/grouplens/grapht/solver/ProviderBindingFunction.java
+++ b/src/main/java/org/grouplens/grapht/solver/ProviderBindingFunction.java
@@ -18,6 +18,7 @@
  */
 package org.grouplens.grapht.solver;
 
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.*;
 import org.grouplens.grapht.util.InstanceProvider;
 import org.grouplens.grapht.util.Types;

--- a/src/test/java/org/grouplens/grapht/BindingFunctionBuilderTest.java
+++ b/src/test/java/org/grouplens/grapht/BindingFunctionBuilderTest.java
@@ -26,7 +26,6 @@ import org.grouplens.grapht.BindingFunctionBuilder.RuleSet;
 import org.grouplens.grapht.solver.BindRule;
 import org.grouplens.grapht.solver.BindRules;
 import org.grouplens.grapht.solver.RuleBasedBindingFunction;
-import org.grouplens.grapht.reflect.CachePolicy;
 import org.grouplens.grapht.reflect.Satisfactions;
 import org.grouplens.grapht.context.ContextElements;
 import org.grouplens.grapht.context.ContextMatcher;

--- a/src/test/java/org/grouplens/grapht/GraphRewritingTest.java
+++ b/src/test/java/org/grouplens/grapht/GraphRewritingTest.java
@@ -19,7 +19,6 @@
 package org.grouplens.grapht;
 
 import org.grouplens.grapht.graph.DAGNode;
-import org.grouplens.grapht.reflect.CachedSatisfaction;
 import org.grouplens.grapht.reflect.Desires;
 import org.grouplens.grapht.solver.DependencySolver;
 import org.grouplens.grapht.solver.SolverException;
@@ -51,12 +50,12 @@ public class GraphRewritingTest {
                                 .addBindingFunction(config.build(BindingFunctionBuilder.RuleSet.EXPLICIT), false)
                                 .build();
         initial.resolve(Desires.create(null, I.class, false));
-        DAGNode<CachedSatisfaction, Dependency> graph = initial.getGraph();
+        DAGNode<Component, Dependency> graph = initial.getGraph();
         assertThat(graph.getOutgoingEdges(), hasSize(1));
         assertThat(graph.getOutgoingEdges().iterator().next()
                         .getTail().getLabel().getSatisfaction().getErasedType(),
                    equalTo((Class) C.class));
-        DAGNode<CachedSatisfaction, Dependency> graph2 = initial.rewrite(graph);
+        DAGNode<Component, Dependency> graph2 = initial.rewrite(graph);
         assertThat(graph2, sameInstance(graph));
     }
 
@@ -74,12 +73,12 @@ public class GraphRewritingTest {
                                 .addBindingFunction(config.build(BindingFunctionBuilder.RuleSet.EXPLICIT), true)
                                 .build();
         initial.resolve(Desires.create(null, I.class, false));
-        DAGNode<CachedSatisfaction, Dependency> graph = initial.getGraph();
+        DAGNode<Component, Dependency> graph = initial.getGraph();
         assertThat(graph.getOutgoingEdges(), hasSize(1));
         assertThat(graph.getOutgoingEdges().iterator().next()
                         .getTail().getLabel().getSatisfaction().getErasedType(),
                    equalTo((Class) C.class));
-        DAGNode<CachedSatisfaction, Dependency> graph2 = initial.rewrite(graph);
+        DAGNode<Component, Dependency> graph2 = initial.rewrite(graph);
         // should trigger a rewrite, but the graph should be unchanged
         assertThat(graph2, sameInstance(graph));
     }
@@ -98,7 +97,7 @@ public class GraphRewritingTest {
                                 .addBindingFunction(config.build(BindingFunctionBuilder.RuleSet.EXPLICIT))
                                 .build();
         initial.resolve(Desires.create(null, I.class, false));
-        DAGNode<CachedSatisfaction, Dependency> graph = initial.getGraph();
+        DAGNode<Component, Dependency> graph = initial.getGraph();
         assertThat(graph.getOutgoingEdges(), hasSize(1));
         assertThat(graph.getOutgoingEdges().iterator().next()
                         .getTail().getLabel().getSatisfaction().getErasedType(),
@@ -117,7 +116,7 @@ public class GraphRewritingTest {
                                 .addBindingFunction(config2.build(BindingFunctionBuilder.RuleSet.EXPLICIT), true)
                                 .build();
 
-        DAGNode<CachedSatisfaction, Dependency> graph2 = rewriter.rewrite(graph);
+        DAGNode<Component, Dependency> graph2 = rewriter.rewrite(graph);
         // should change the dependency
         assertThat(graph2, not(sameInstance(graph)));
         assertThat(graph2.getOutgoingEdges(), hasSize(1));
@@ -144,7 +143,7 @@ public class GraphRewritingTest {
                                 .addBindingFunction(config.build(BindingFunctionBuilder.RuleSet.EXPLICIT))
                                 .build();
         initial.resolve(Desires.create(null, I.class, false));
-        DAGNode<CachedSatisfaction, Dependency> graph = initial.getGraph();
+        DAGNode<Component, Dependency> graph = initial.getGraph();
         assertThat(graph.getOutgoingEdges(), hasSize(1));
         assertThat(graph.getOutgoingEdges().iterator().next()
                         .getTail().getLabel().getSatisfaction().getErasedType(),
@@ -168,7 +167,7 @@ public class GraphRewritingTest {
                                 .addBindingFunction(rewriteDeps.build(BindingFunctionBuilder.RuleSet.EXPLICIT), false)
                                 .build();
 
-        DAGNode<CachedSatisfaction, Dependency> graph2 = rewriter.rewrite(graph);
+        DAGNode<Component, Dependency> graph2 = rewriter.rewrite(graph);
         // should change the dependency
         assertThat(graph2, not(sameInstance(graph)));
         assertThat(graph2.getOutgoingEdges(), hasSize(1));
@@ -197,7 +196,7 @@ public class GraphRewritingTest {
                                 .addBindingFunction(config.build(BindingFunctionBuilder.RuleSet.EXPLICIT))
                                 .build();
         initial.resolve(Desires.create(null, I.class, false));
-        DAGNode<CachedSatisfaction, Dependency> graph = initial.getGraph();
+        DAGNode<Component, Dependency> graph = initial.getGraph();
 
         BindingFunctionBuilder config2 = new BindingFunctionBuilder();
         config2.getRootContext()
@@ -208,7 +207,7 @@ public class GraphRewritingTest {
                                 .addBindingFunction(config2.build(BindingFunctionBuilder.RuleSet.EXPLICIT), true)
                                 .build();
 
-        DAGNode<CachedSatisfaction, Dependency> graph2 = rewriter.rewrite(graph);
+        DAGNode<Component, Dependency> graph2 = rewriter.rewrite(graph);
         // should be unchanged, because of fixed binding
         assertThat(graph2, sameInstance(graph));
     }

--- a/src/test/java/org/grouplens/grapht/InjectorBuilderTest.java
+++ b/src/test/java/org/grouplens/grapht/InjectorBuilderTest.java
@@ -19,7 +19,6 @@
 package org.grouplens.grapht;
 
 import org.grouplens.grapht.annotation.AnnotationBuilder;
-import org.grouplens.grapht.reflect.CachePolicy;
 import org.grouplens.grapht.reflect.internal.types.*;
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/org/grouplens/grapht/TckTest.java
+++ b/src/test/java/org/grouplens/grapht/TckTest.java
@@ -23,7 +23,6 @@ import junit.framework.TestCase;
 import org.atinject.tck.Tck;
 import org.atinject.tck.auto.*;
 import org.atinject.tck.auto.accessories.SpareTire;
-import org.grouplens.grapht.reflect.CachePolicy;
 
 public class TckTest extends TestCase {
     

--- a/src/test/java/org/grouplens/grapht/graph/SerializationTest.java
+++ b/src/test/java/org/grouplens/grapht/graph/SerializationTest.java
@@ -22,8 +22,8 @@ import org.grouplens.grapht.BindingFunctionBuilder;
 import org.grouplens.grapht.BindingFunctionBuilder.RuleSet;
 import org.grouplens.grapht.Dependency;
 import org.grouplens.grapht.annotation.AnnotationBuilder;
-import org.grouplens.grapht.reflect.CachePolicy;
-import org.grouplens.grapht.reflect.CachedSatisfaction;
+import org.grouplens.grapht.CachePolicy;
+import org.grouplens.grapht.Component;
 import org.grouplens.grapht.reflect.Desires;
 import org.grouplens.grapht.reflect.Satisfactions;
 import org.grouplens.grapht.reflect.internal.InstanceSatisfaction;
@@ -47,10 +47,10 @@ public class SerializationTest {
     
     @Test
     public void testEmptyGraph() throws Exception {
-        DAGNode<CachedSatisfaction, DesireChain> g =
+        DAGNode<Component, DesireChain> g =
                 DAGNode.singleton(DependencySolver.ROOT_SATISFACTION);
         write(g);
-        DAGNode<CachedSatisfaction, DesireChain> read = read();
+        DAGNode<Component, DesireChain> read = read();
 
         assertThat(read.getReachableNodes(),
                    contains(read));
@@ -58,11 +58,11 @@ public class SerializationTest {
     
     @Test
     public void testSharedNodesGraph() throws Exception {
-        CachedSatisfaction s1 = new CachedSatisfaction(Satisfactions.type(Object.class), CachePolicy.NEW_INSTANCE);
-        CachedSatisfaction s2 = new CachedSatisfaction(Satisfactions.type(Object.class), CachePolicy.MEMOIZE);
+        Component s1 = Component.create(Satisfactions.type(Object.class), CachePolicy.NEW_INSTANCE);
+        Component s2 = Component.create(Satisfactions.type(Object.class), CachePolicy.MEMOIZE);
 
-        DAGNode<CachedSatisfaction, String> n2 = DAGNode.singleton(s2);
-        DAGNodeBuilder<CachedSatisfaction, String> bld = DAGNode.newBuilder(s1);
+        DAGNode<Component, String> n2 = DAGNode.singleton(s2);
+        DAGNodeBuilder<Component, String> bld = DAGNode.newBuilder(s1);
         bld.addEdge(n2, "wombat");
         bld.addEdge(n2, "foobar");
         write(bld.build());
@@ -87,13 +87,13 @@ public class SerializationTest {
                                                   .build();
         solver.resolve(Desires.create(null, NamedType.class, false));
         
-        DAGNode<CachedSatisfaction,Dependency> g = solver.getGraph();
+        DAGNode<Component,Dependency> g = solver.getGraph();
         write(g);
-        DAGNode<CachedSatisfaction, Dependency> root = read();
+        DAGNode<Component, Dependency> root = read();
         
         Assert.assertEquals(1, root.getOutgoingEdges().size());
-        DAGEdge<CachedSatisfaction, Dependency> rootEdge = root.getOutgoingEdges().iterator().next();
-        DAGNode<CachedSatisfaction, Dependency> namedType = rootEdge.getTail();
+        DAGEdge<Component, Dependency> rootEdge = root.getOutgoingEdges().iterator().next();
+        DAGNode<Component, Dependency> namedType = rootEdge.getTail();
         
         Assert.assertEquals(NamedType.class, namedType.getLabel().getSatisfaction().getErasedType());
         Assert.assertEquals(NamedType.class, rootEdge.getLabel().getInitialDesire().getDesiredType());
@@ -102,8 +102,8 @@ public class SerializationTest {
         Assert.assertTrue(rootEdge.getLabel().getInitialDesire().getInjectionPoint().getAttributes().isEmpty());
         
         Assert.assertEquals(1, namedType.getOutgoingEdges().size());
-        DAGEdge<CachedSatisfaction, Dependency> nameEdge = namedType.getOutgoingEdges().iterator().next();
-        DAGNode<CachedSatisfaction, Dependency> string = nameEdge.getTail();
+        DAGEdge<Component, Dependency> nameEdge = namedType.getOutgoingEdges().iterator().next();
+        DAGNode<Component, Dependency> string = nameEdge.getTail();
         
         Assert.assertEquals(String.class, string.getLabel().getSatisfaction().getErasedType());
         Assert.assertEquals(String.class, nameEdge.getLabel().getInitialDesire().getDesiredType());

--- a/src/test/java/org/grouplens/grapht/reflect/MockSatisfaction.java
+++ b/src/test/java/org/grouplens/grapht/reflect/MockSatisfaction.java
@@ -18,6 +18,8 @@
  */
 package org.grouplens.grapht.reflect;
 
+import org.grouplens.grapht.CachePolicy;
+
 import javax.inject.Provider;
 import java.lang.reflect.Type;
 import java.util.ArrayList;

--- a/src/test/java/org/grouplens/grapht/reflect/internal/ReflectionInjectionTest.java
+++ b/src/test/java/org/grouplens/grapht/reflect/internal/ReflectionInjectionTest.java
@@ -27,7 +27,7 @@ import org.grouplens.grapht.Injector;
 import org.grouplens.grapht.InjectorBuilder;
 import org.grouplens.grapht.graph.DAGEdge;
 import org.grouplens.grapht.graph.DAGNode;
-import org.grouplens.grapht.reflect.CachedSatisfaction;
+import org.grouplens.grapht.Component;
 import org.grouplens.grapht.reflect.Desire;
 import org.grouplens.grapht.reflect.Desires;
 import org.grouplens.grapht.reflect.InjectionPoint;
@@ -50,28 +50,28 @@ public class ReflectionInjectionTest {
         Injector i = b.build();
         
         i.getInstance(CycleA.class);
-        DAGNode<CachedSatisfaction,Dependency> root = ((DefaultInjector) i).getSolver().getGraph();
+        DAGNode<Component,Dependency> root = ((DefaultInjector) i).getSolver().getGraph();
 
         assertThat(root.getReachableNodes(), hasSize(3 + 1));
 
         assertThat(root.getOutgoingEdges(), hasSize(1));
-        DAGNode<CachedSatisfaction, Dependency> anode = root.getOutgoingEdges().iterator().next().getTail();
+        DAGNode<Component, Dependency> anode = root.getOutgoingEdges().iterator().next().getTail();
         Assert.assertEquals(CycleA.class, anode.getLabel().getSatisfaction().getErasedType());
         
         Assert.assertEquals(1, anode.getOutgoingEdges().size());
-        DAGNode<CachedSatisfaction, Dependency> bnode = anode.getOutgoingEdges().iterator().next().getTail();
+        DAGNode<Component, Dependency> bnode = anode.getOutgoingEdges().iterator().next().getTail();
         Assert.assertEquals(CycleB.class, bnode.getLabel().getSatisfaction().getErasedType());
         
         Assert.assertEquals(1, bnode.getOutgoingEdges().size());
-        DAGNode<CachedSatisfaction, Dependency> pnode = bnode.getOutgoingEdges().iterator().next().getTail();
+        DAGNode<Component, Dependency> pnode = bnode.getOutgoingEdges().iterator().next().getTail();
         Assert.assertEquals(Provider.class, pnode.getLabel().getSatisfaction().getErasedType());
 
         // no outgoing edges...
         Assert.assertEquals(0, pnode.getOutgoingEdges().size());
         // but a back edge
-        ImmutableSet<DAGEdge<CachedSatisfaction, Dependency>> backEdges = ((DefaultInjector) i).getSolver().getBackEdges();
+        ImmutableSet<DAGEdge<Component, Dependency>> backEdges = ((DefaultInjector) i).getSolver().getBackEdges();
         assertThat(backEdges, hasSize(1));
-        DAGEdge<CachedSatisfaction, Dependency> edge = backEdges.iterator().next();
+        DAGEdge<Component, Dependency> edge = backEdges.iterator().next();
         Assert.assertSame(anode, edge.getTail());
     }
     
@@ -94,13 +94,13 @@ public class ReflectionInjectionTest {
         // also verify memoization
         Assert.assertSame(instance, r.getInstance(TypeC.class));
 
-        DAGNode<CachedSatisfaction, Dependency> resolvedRoot =
+        DAGNode<Component, Dependency> resolvedRoot =
                 r.getSolver().getGraph().getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(rootDesire)).getTail();
         assertThat(resolvedRoot.getOutgoingEdges(),
                    hasSize(5));
 
-        Map<InjectionPoint, DAGNode<CachedSatisfaction, Dependency>> deps = Maps.newHashMap();
-        for (DAGEdge<CachedSatisfaction, Dependency> e: resolvedRoot.getOutgoingEdges()) {
+        Map<InjectionPoint, DAGNode<Component, Dependency>> deps = Maps.newHashMap();
+        for (DAGEdge<Component, Dependency> e: resolvedRoot.getOutgoingEdges()) {
             ReflectionDesire d = (ReflectionDesire) e.getLabel().getInitialDesire();
             
             if (d.getInjectionPoint().equals(TypeC.CONSTRUCTOR)) {
@@ -181,13 +181,13 @@ public class ReflectionInjectionTest {
         // also verify memoization
         Assert.assertSame(instance, r.getInstance(TypeC.class));
 
-        DAGNode<CachedSatisfaction, Dependency> resolvedRoot =
+        DAGNode<Component, Dependency> resolvedRoot =
                 r.getSolver().getGraph().getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(rootDesire)).getTail();
         assertThat(resolvedRoot.getOutgoingEdges(),
                    hasSize(5));
         
-        Map<InjectionPoint, DAGNode<CachedSatisfaction, Dependency>> deps = Maps.newHashMap();
-        for (DAGEdge<CachedSatisfaction, Dependency> e: resolvedRoot.getOutgoingEdges()) {
+        Map<InjectionPoint, DAGNode<Component, Dependency>> deps = Maps.newHashMap();
+        for (DAGEdge<Component, Dependency> e: resolvedRoot.getOutgoingEdges()) {
             ReflectionDesire d = (ReflectionDesire) e.getLabel().getInitialDesire();
             
             if (d.getInjectionPoint().equals(TypeC.CONSTRUCTOR)) {

--- a/src/test/java/org/grouplens/grapht/solver/BindRuleTest.java
+++ b/src/test/java/org/grouplens/grapht/solver/BindRuleTest.java
@@ -18,6 +18,7 @@
  */
 package org.grouplens.grapht.solver;
 
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.annotation.AnnotationBuilder;
 import org.grouplens.grapht.reflect.*;
 import org.grouplens.grapht.reflect.internal.*;

--- a/src/test/java/org/grouplens/grapht/solver/DependencySolverTest.java
+++ b/src/test/java/org/grouplens/grapht/solver/DependencySolverTest.java
@@ -20,6 +20,8 @@ package org.grouplens.grapht.solver;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.*;
+import org.grouplens.grapht.CachePolicy;
+import org.grouplens.grapht.Component;
 import org.grouplens.grapht.Dependency;
 import org.grouplens.grapht.annotation.AnnotationBuilder;
 import org.grouplens.grapht.context.ContextElements;
@@ -53,7 +55,7 @@ public class DependencySolverTest {
     }
     
     // bypass synthetic root and return node that resolves the desire 
-    private DAGNode<CachedSatisfaction, Dependency> getRoot(DependencySolver r, Desire d) {
+    private DAGNode<Component, Dependency> getRoot(DependencySolver r, Desire d) {
         return r.getGraph().getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(d)).getTail();
     }
     
@@ -83,14 +85,14 @@ public class DependencySolverTest {
         assertThat(r.getGraph().getReachableNodes(),
                    hasSize(3 + 1));
 
-        DAGNode<CachedSatisfaction, Dependency> bnode = getRoot(r, rb);
+        DAGNode<Component, Dependency> bnode = getRoot(r, rb);
         Assert.assertEquals(CachePolicy.NO_PREFERENCE, bnode.getLabel().getCachePolicy());
         
-        DAGNode<CachedSatisfaction, Dependency> adepnode = getNode(bnode, sa, da);
+        DAGNode<Component, Dependency> adepnode = getNode(bnode, sa, da);
         Assert.assertNotNull(adepnode);
         Assert.assertEquals(CachePolicy.MEMOIZE, adepnode.getLabel().getCachePolicy());
         
-        DAGNode<CachedSatisfaction, Dependency> anode = getRoot(r, da);
+        DAGNode<Component, Dependency> anode = getRoot(r, da);
         Assert.assertNotSame(adepnode, anode);
         Assert.assertEquals(CachePolicy.NEW_INSTANCE, anode.getLabel().getCachePolicy());
     }
@@ -105,7 +107,7 @@ public class DependencySolverTest {
         r.resolve(desire);
         assertThat(r.getGraph().getReachableNodes(), hasSize(2));
 
-        DAGNode<CachedSatisfaction, Dependency> node = getRoot(r, desire);
+        DAGNode<Component, Dependency> node = getRoot(r, desire);
         Assert.assertEquals(sat, node.getLabel().getSatisfaction());
         Assert.assertTrue(node.getOutgoingEdges().isEmpty());
         Assert.assertTrue(r.getGraph().getReachableNodes().contains(node));
@@ -122,7 +124,7 @@ public class DependencySolverTest {
         DependencySolver r = createSolver(ArrayListMultimap.<ContextMatcher, BindRule>create());
         r.resolve(rootDesire);
         
-        DAGNode<CachedSatisfaction, Dependency> rootNode = getRoot(r, rootDesire);
+        DAGNode<Component, Dependency> rootNode = getRoot(r, rootDesire);
         Assert.assertEquals(2 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(rootSat, rootNode.getLabel().getSatisfaction());
         Assert.assertEquals(1, rootNode.getOutgoingEdges().size());
@@ -145,7 +147,7 @@ public class DependencySolverTest {
                         new MockBindRule(d2, d3));
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
-        DAGNode<CachedSatisfaction, Dependency> rootNode = getRoot(r, rootDesire);
+        DAGNode<Component, Dependency> rootNode = getRoot(r, rootDesire);
         
         Assert.assertEquals(2 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(root, rootNode.getLabel().getSatisfaction());
@@ -173,7 +175,7 @@ public class DependencySolverTest {
         Desire rootDesire = new MockDesire(root);
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
-        DAGNode<CachedSatisfaction, Dependency> rootNode = getRoot(r, rootDesire);
+        DAGNode<Component, Dependency> rootNode = getRoot(r, rootDesire);
 
         Assert.assertEquals(2 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(root, rootNode.getLabel().getSatisfaction());
@@ -205,15 +207,15 @@ public class DependencySolverTest {
         Desire rootDesire = new MockDesire(s1);
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
-        DAGNode<CachedSatisfaction, Dependency> rootNode = getRoot(r, rootDesire);
+        DAGNode<Component, Dependency> rootNode = getRoot(r, rootDesire);
         
         Assert.assertEquals(3 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(s1, rootNode.getLabel().getSatisfaction());
         
-        DAGNode<CachedSatisfaction, Dependency> n1 =
-                getNode(r.getGraph(), new CachedSatisfaction(s1, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n2 = getNode(r.getGraph(), new CachedSatisfaction(s2, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n3 = getNode(r.getGraph(), new CachedSatisfaction(s3, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n1 =
+                getNode(r.getGraph(), Component.create(s1, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n2 = getNode(r.getGraph(), Component.create(s2, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n3 = getNode(r.getGraph(), Component.create(s3, CachePolicy.NO_PREFERENCE));
 
         assertThat(Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))),
                    hasSize(1));
@@ -265,14 +267,14 @@ public class DependencySolverTest {
         Desire rootDesire = new MockDesire(r1);
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
-        DAGNode<CachedSatisfaction, Dependency> rootNode = getRoot(r, rootDesire);
+        DAGNode<Component, Dependency> rootNode = getRoot(r, rootDesire);
         
         Assert.assertEquals(5 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
-        DAGNode<CachedSatisfaction, Dependency> n1 = getNode(r.getGraph(), new CachedSatisfaction(r1, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n2 = getNode(r.getGraph(), new CachedSatisfaction(r2, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n3 = getNode(r.getGraph(), new CachedSatisfaction(r3, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n4 = getNode(r.getGraph(), new CachedSatisfaction(r4, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> on4 = getNode(r.getGraph(), new CachedSatisfaction(or4, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n1 = getNode(r.getGraph(), Component.create(r1, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n2 = getNode(r.getGraph(), Component.create(r2, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n3 = getNode(r.getGraph(), Component.create(r3, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n4 = getNode(r.getGraph(), Component.create(r4, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> on4 = getNode(r.getGraph(), Component.create(or4, CachePolicy.NO_PREFERENCE));
 
         Assert.assertEquals(n1, rootNode);
         Assert.assertEquals(2, n1.getOutgoingEdges().size());
@@ -310,7 +312,7 @@ public class DependencySolverTest {
         Desire rootDesire = new MockDesire(r1);
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
-        DAGNode<CachedSatisfaction, Dependency> rootNode = getRoot(r, rootDesire);
+        DAGNode<Component, Dependency> rootNode = getRoot(r, rootDesire);
 
         Assert.assertEquals(2 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(r1, rootNode.getLabel().getSatisfaction());
@@ -350,10 +352,10 @@ public class DependencySolverTest {
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
         
-        DAGNode<CachedSatisfaction, Dependency> n1 = getNode(r.getGraph(), new CachedSatisfaction(r1, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n2 = getNode(r.getGraph(), new CachedSatisfaction(r2, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n3 = getNode(r.getGraph(), new CachedSatisfaction(r3, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> on3 = getNode(r.getGraph(), new CachedSatisfaction(or3, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n1 = getNode(r.getGraph(), Component.create(r1, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n2 = getNode(r.getGraph(), Component.create(r2, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n3 = getNode(r.getGraph(), Component.create(r3, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> on3 = getNode(r.getGraph(), Component.create(or3, CachePolicy.NO_PREFERENCE));
 
         Assert.assertEquals(3 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertNotNull(n1);
@@ -404,10 +406,10 @@ public class DependencySolverTest {
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
         
-        DAGNode<CachedSatisfaction, Dependency> n1 = getNode(r.getGraph(), new CachedSatisfaction(r1, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n2 = getNode(r.getGraph(), new CachedSatisfaction(r2, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n3 = getNode(r.getGraph(), new CachedSatisfaction(r3, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> on3 = getNode(r.getGraph(), new CachedSatisfaction(or3, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n1 = getNode(r.getGraph(), Component.create(r1, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n2 = getNode(r.getGraph(), Component.create(r2, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n3 = getNode(r.getGraph(), Component.create(r3, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> on3 = getNode(r.getGraph(), Component.create(or3, CachePolicy.NO_PREFERENCE));
 
         Assert.assertEquals(3 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertNotNull(n1);
@@ -449,9 +451,9 @@ public class DependencySolverTest {
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
         
-        DAGNode<CachedSatisfaction, Dependency> n1 = getNode(r.getGraph(), new CachedSatisfaction(r1, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n2 = getNode(r.getGraph(), new CachedSatisfaction(r2, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> on2 = getNode(r.getGraph(), new CachedSatisfaction(or2, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n1 = getNode(r.getGraph(), Component.create(r1, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n2 = getNode(r.getGraph(), Component.create(r2, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> on2 = getNode(r.getGraph(), Component.create(or2, CachePolicy.NO_PREFERENCE));
 
         Assert.assertEquals(2 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertNotNull(n1);
@@ -487,15 +489,15 @@ public class DependencySolverTest {
         Desire rootDesire = new MockDesire(r1);
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
-        DAGNode<CachedSatisfaction, Dependency> rootNode = getRoot(r, rootDesire);
+        DAGNode<Component, Dependency> rootNode = getRoot(r, rootDesire);
         
         Assert.assertEquals(4 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(r1, rootNode.getLabel().getSatisfaction());
         Assert.assertEquals(3, rootNode.getOutgoingEdges().size());
         
-        DAGNode<CachedSatisfaction, Dependency> n1 = getNode(r.getGraph(), new CachedSatisfaction(sd1, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n2 = getNode(r.getGraph(), new CachedSatisfaction(sd2, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n3 = getNode(r.getGraph(), new CachedSatisfaction(sd3, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n1 = getNode(r.getGraph(), Component.create(sd1, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n2 = getNode(r.getGraph(), Component.create(sd2, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n3 = getNode(r.getGraph(), Component.create(sd3, CachePolicy.NO_PREFERENCE));
         
         Assert.assertEquals(1, Sets.filter(rootNode.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n1))).size());
         Assert.assertEquals(d1, Sets.filter(rootNode.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n1))).iterator().next().getLabel().getInitialDesire());
@@ -510,7 +512,7 @@ public class DependencySolverTest {
     @Test
     public void testMultipleRootsSharedDependencySuccess() throws Exception {
         // Test multiple root desires that resolve to nodes that share
-        // a dependency, and verify that the resolved dependency is the same DAGNode<CachedSatisfaction, DesireChain>
+        // a dependency, and verify that the resolved dependency is the same DAGNode<Component, DesireChain>
         Desire d1 = new MockDesire();
         Desire d2 = new MockDesire();
         Desire d3 = new MockDesire();
@@ -531,14 +533,14 @@ public class DependencySolverTest {
         Desire rootDesire = new MockDesire(r1);
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
-        DAGNode<CachedSatisfaction, Dependency> rootNode = getRoot(r, rootDesire);
+        DAGNode<Component, Dependency> rootNode = getRoot(r, rootDesire);
         
         Assert.assertEquals(2 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(r1, rootNode.getLabel().getSatisfaction());
         Assert.assertEquals(3, rootNode.getOutgoingEdges().size());
         
         Set<Desire> edges = new HashSet<Desire>();
-        for (DAGEdge<CachedSatisfaction, Dependency> e: rootNode.getOutgoingEdges()) {
+        for (DAGEdge<Component, Dependency> e: rootNode.getOutgoingEdges()) {
             Assert.assertEquals(sd1, e.getTail().getLabel().getSatisfaction());
             edges.add(e.getLabel().getInitialDesire());
         }
@@ -569,14 +571,14 @@ public class DependencySolverTest {
         Desire rootDesire = new MockDesire(s1);
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
-        DAGNode<CachedSatisfaction, Dependency> rootNode = getRoot(r, rootDesire);
+        DAGNode<Component, Dependency> rootNode = getRoot(r, rootDesire);
         
         Assert.assertEquals(3 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(s1, rootNode.getLabel().getSatisfaction());
         
-        DAGNode<CachedSatisfaction, Dependency> n1 = getNode(r.getGraph(), new CachedSatisfaction(s1, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n2 = getNode(r.getGraph(), new CachedSatisfaction(s2, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n3 = getNode(r.getGraph(), new CachedSatisfaction(s3, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n1 = getNode(r.getGraph(), Component.create(s1, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n2 = getNode(r.getGraph(), Component.create(s2, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n3 = getNode(r.getGraph(), Component.create(s3, CachePolicy.NO_PREFERENCE));
         
         Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).size());
         Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).iterator().next().getLabel().getInitialDesire());
@@ -642,24 +644,24 @@ public class DependencySolverTest {
         Desire rootDesire = new MockDesire(s1);
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
-        DAGNode<CachedSatisfaction, Dependency> rootNode = getRoot(r, rootDesire);
+        DAGNode<Component, Dependency> rootNode = getRoot(r, rootDesire);
         
         // there are 10 nodes, s2, s4 and s5 are duplicated
         Assert.assertEquals(10 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         
         // grab all of the nodes in the graph
-        DAGNode<CachedSatisfaction, Dependency> n1 = rootNode;
-        DAGNode<CachedSatisfaction, Dependency> n2 = getNode(n1, s2, d1);
-        DAGNode<CachedSatisfaction, Dependency> on2 = getNode(n1, s2, d2);
-        DAGNode<CachedSatisfaction, Dependency> n3 = getNode(n2, s3, d3);
-        DAGNode<CachedSatisfaction, Dependency> n4 = getNode(n2, s4, d4);
-        DAGNode<CachedSatisfaction, Dependency> on4 = getNode(on2, s4, d3); // should equal n4
-        DAGNode<CachedSatisfaction, Dependency> oon4 = getNode(on2, s4, d4); // should not equal n4 and on4
-        DAGNode<CachedSatisfaction, Dependency> n5 = getNode(n3, s5, d5);
-        DAGNode<CachedSatisfaction, Dependency> on5 = getNode(on4, s5, d6); // should equal n5
-        DAGNode<CachedSatisfaction, Dependency> oon5 = getNode(oon4, s5, d6); // should not equal n5 and on5
-        DAGNode<CachedSatisfaction, Dependency> n6 = getNode(n5, s6, d7);
-        DAGNode<CachedSatisfaction, Dependency> n7 = getNode(oon5, s7, d7);
+        DAGNode<Component, Dependency> n1 = rootNode;
+        DAGNode<Component, Dependency> n2 = getNode(n1, s2, d1);
+        DAGNode<Component, Dependency> on2 = getNode(n1, s2, d2);
+        DAGNode<Component, Dependency> n3 = getNode(n2, s3, d3);
+        DAGNode<Component, Dependency> n4 = getNode(n2, s4, d4);
+        DAGNode<Component, Dependency> on4 = getNode(on2, s4, d3); // should equal n4
+        DAGNode<Component, Dependency> oon4 = getNode(on2, s4, d4); // should not equal n4 and on4
+        DAGNode<Component, Dependency> n5 = getNode(n3, s5, d5);
+        DAGNode<Component, Dependency> on5 = getNode(on4, s5, d6); // should equal n5
+        DAGNode<Component, Dependency> oon5 = getNode(oon4, s5, d6); // should not equal n5 and on5
+        DAGNode<Component, Dependency> n6 = getNode(n5, s6, d7);
+        DAGNode<Component, Dependency> n7 = getNode(oon5, s7, d7);
         
         // make sure that node states are as expected, if they're not null then
         // they match the satisfaction and desire in the query
@@ -732,44 +734,44 @@ public class DependencySolverTest {
         Desire rootDesire = new MockDesire(s1);
         DependencySolver r = createSolver(bindings.build());
         r.resolve(rootDesire);
-        DAGNode<CachedSatisfaction, Dependency> rootNode = getRoot(r, rootDesire);
+        DAGNode<Component, Dependency> rootNode = getRoot(r, rootDesire);
         
         // the resulting graph should be s1->s2->s1->s2->s1->os2 = 6 nodes
         Assert.assertEquals(6 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(s1, rootNode.getLabel().getSatisfaction());
         
         // edge s1->s2 by d1
-        Set<DAGEdge<CachedSatisfaction, Dependency>> edges = rootNode.getOutgoingEdges();
+        Set<DAGEdge<Component, Dependency>> edges = rootNode.getOutgoingEdges();
         Assert.assertEquals(1, edges.size());
-        DAGEdge<CachedSatisfaction, Dependency> e1 = edges.iterator().next();
+        DAGEdge<Component, Dependency> e1 = edges.iterator().next();
         Assert.assertEquals(s2, e1.getTail().getLabel().getSatisfaction());
         Assert.assertEquals(d1, e1.getLabel().getInitialDesire());
         
         // edge s2->s1 by d2
         edges = e1.getTail().getOutgoingEdges();
         Assert.assertEquals(1, edges.size());
-        DAGEdge<CachedSatisfaction, Dependency> e2 = edges.iterator().next();
+        DAGEdge<Component, Dependency> e2 = edges.iterator().next();
         Assert.assertEquals(s1, e2.getTail().getLabel().getSatisfaction());
         Assert.assertEquals(d2, e2.getLabel().getInitialDesire());
         
         // edge s1->s2 by d1
         edges = e2.getTail().getOutgoingEdges();
         Assert.assertEquals(1, edges.size());
-        DAGEdge<CachedSatisfaction, Dependency> e3 = edges.iterator().next();
+        DAGEdge<Component, Dependency> e3 = edges.iterator().next();
         Assert.assertEquals(s2, e3.getTail().getLabel().getSatisfaction());
         Assert.assertEquals(d1, e3.getLabel().getInitialDesire());
         
         // edge s2->s1 by d2
         edges = e3.getTail().getOutgoingEdges();
         Assert.assertEquals(1, edges.size());
-        DAGEdge<CachedSatisfaction, Dependency> e4 = edges.iterator().next();
+        DAGEdge<Component, Dependency> e4 = edges.iterator().next();
         Assert.assertEquals(s1, e4.getTail().getLabel().getSatisfaction());
         Assert.assertEquals(d2, e4.getLabel().getInitialDesire());
         
         // edge s1->os2 by d1
         edges = e4.getTail().getOutgoingEdges();
         Assert.assertEquals(1, edges.size());
-        DAGEdge<CachedSatisfaction, Dependency> e5 = edges.iterator().next();
+        DAGEdge<Component, Dependency> e5 = edges.iterator().next();
         Assert.assertEquals(os2, e5.getTail().getLabel().getSatisfaction());
         Assert.assertEquals(d1, e5.getLabel().getInitialDesire());
         
@@ -804,8 +806,8 @@ public class DependencySolverTest {
         
         Assert.assertEquals(2 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         
-        DAGNode<CachedSatisfaction, Dependency> n1 = getNode(r.getGraph(), new CachedSatisfaction(s1, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n2 = getNode(r.getGraph(), new CachedSatisfaction(s2, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n1 = getNode(r.getGraph(), Component.create(s1, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n2 = getNode(r.getGraph(), Component.create(s2, CachePolicy.NO_PREFERENCE));
         
         Assert.assertNotNull(n1);
         Assert.assertNotNull(n2);
@@ -838,8 +840,8 @@ public class DependencySolverTest {
         
         Assert.assertEquals(2 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         
-        DAGNode<CachedSatisfaction, Dependency> n1 = getNode(r.getGraph(), new CachedSatisfaction(s1, CachePolicy.NO_PREFERENCE));
-        DAGNode<CachedSatisfaction, Dependency> n2 = getNode(r.getGraph(), new CachedSatisfaction(s2, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n1 = getNode(r.getGraph(), Component.create(s1, CachePolicy.NO_PREFERENCE));
+        DAGNode<Component, Dependency> n2 = getNode(r.getGraph(), Component.create(s2, CachePolicy.NO_PREFERENCE));
         
         Assert.assertNotNull(n1);
         Assert.assertNotNull(n2);
@@ -874,20 +876,20 @@ public class DependencySolverTest {
         r.resolve(da);
         r.resolve(dap);
         
-        DAGNode<CachedSatisfaction, Dependency> root = r.getGraph();
+        DAGNode<Component, Dependency> root = r.getGraph();
         Assert.assertEquals(5 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(2, root.getOutgoingEdges().size()); // da and dap
         
-        DAGNode<CachedSatisfaction, Dependency> na =
+        DAGNode<Component, Dependency> na =
                 root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(da)).getTail();
-        DAGNode<CachedSatisfaction, Dependency> nap = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(dap)).getTail();
+        DAGNode<Component, Dependency> nap = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(dap)).getTail();
         
         // sa and sap were different satisfactions, so they should be separate nodes
         Assert.assertNotSame(na, nap);
         
         // the resolved desire for a1, from da
-        DAGNode<CachedSatisfaction, Dependency> ra1 = na.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
-        DAGNode<CachedSatisfaction, Dependency> ra1p = nap.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
+        DAGNode<Component, Dependency> ra1 = na.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
+        DAGNode<Component, Dependency> ra1p = nap.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
         
         // verify that both a and ap point to the sb satisfaction, and verify
         // that sb (and also its children) are properly shared
@@ -895,9 +897,9 @@ public class DependencySolverTest {
         Assert.assertSame(sd, ra1p.getLabel().getSatisfaction());
         Assert.assertSame(ra1, ra1p);
 
-        DAGNode<CachedSatisfaction, Dependency> node =
+        DAGNode<Component, Dependency> node =
                 Iterables.find(r.getGraph().getReachableNodes(),
-                               DAGNode.labelMatches(Predicates.equalTo(new CachedSatisfaction(sd, CachePolicy.NO_PREFERENCE))));
+                               DAGNode.labelMatches(Predicates.equalTo(Component.create(sd, CachePolicy.NO_PREFERENCE))));
         assertThat(r.getGraph().getIncomingEdges(node),
                    hasSize(2));
     }
@@ -936,19 +938,19 @@ public class DependencySolverTest {
         r.resolve(da);
         r.resolve(dap);
         
-        DAGNode<CachedSatisfaction, Dependency> root = r.getGraph();
+        DAGNode<Component, Dependency> root = r.getGraph();
         Assert.assertEquals(8 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(2, root.getOutgoingEdges().size()); // da and dap
         
-        DAGNode<CachedSatisfaction, Dependency> na = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(da)).getTail();
-        DAGNode<CachedSatisfaction, Dependency> nap = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(dap)).getTail();
+        DAGNode<Component, Dependency> na = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(da)).getTail();
+        DAGNode<Component, Dependency> nap = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(dap)).getTail();
         
         // sa and sap were different satisfactions, so they should be separate nodes
         Assert.assertNotSame(na, nap);
         
         // the resolved desire for a1, from da
-        DAGNode<CachedSatisfaction, Dependency> ra1 = na.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
-        DAGNode<CachedSatisfaction, Dependency> ra1p = nap.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
+        DAGNode<Component, Dependency> ra1 = na.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
+        DAGNode<Component, Dependency> ra1p = nap.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
         
         // verify that both ra1 and ra1p are different nodes that both use the
         // sd satisfaction because sd's dependencies are configured differently
@@ -987,12 +989,12 @@ public class DependencySolverTest {
         r.resolve(da);
         r.resolve(dd);
         
-        DAGNode<CachedSatisfaction, Dependency> root = r.getGraph();
+        DAGNode<Component, Dependency> root = r.getGraph();
         Assert.assertEquals(4 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(2, root.getOutgoingEdges().size()); // da and dd
         
-        DAGNode<CachedSatisfaction, Dependency> na = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(da)).getTail();
-        DAGNode<CachedSatisfaction, Dependency> nd = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(dd)).getTail();
+        DAGNode<Component, Dependency> na = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(da)).getTail();
+        DAGNode<Component, Dependency> nd = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(dd)).getTail();
         
         // additionally verify that there is an edge going from na to nd
         Assert.assertEquals(1, Sets.filter(na.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(nd))).size());
@@ -1033,19 +1035,19 @@ public class DependencySolverTest {
         r.resolve(da);
         r.resolve(dd);
         
-        DAGNode<CachedSatisfaction, Dependency> root = r.getGraph();
+        DAGNode<Component, Dependency> root = r.getGraph();
         Assert.assertEquals(7 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(2, root.getOutgoingEdges().size()); // da and dd
         
         // resolved root desire nodes
-        DAGNode<CachedSatisfaction, Dependency> na = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(da)).getTail();
-        DAGNode<CachedSatisfaction, Dependency> nd = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(dd)).getTail();
+        DAGNode<Component, Dependency> na = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(da)).getTail();
+        DAGNode<Component, Dependency> nd = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(dd)).getTail();
         
         // make sure that there is no edge between na and nd
         Assert.assertTrue(Sets.filter(na.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(nd))).isEmpty());
         
         // look up dependency for na (which is also the sd satisfaction)
-        DAGNode<CachedSatisfaction, Dependency> nad = na.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
+        DAGNode<Component, Dependency> nad = na.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
         
         // verify that the two sd nodes are different and have different edge
         // configurations
@@ -1178,8 +1180,8 @@ public class DependencySolverTest {
     }
     
     // Find the node for s connected to p by the given desire, d
-    private DAGNode<CachedSatisfaction, Dependency> getNode(DAGNode<CachedSatisfaction, Dependency> graph, Satisfaction s, Desire d) {
-        for (DAGEdge<CachedSatisfaction, Dependency> e: graph.getOutgoingEdges()) {
+    private DAGNode<Component, Dependency> getNode(DAGNode<Component, Dependency> graph, Satisfaction s, Desire d) {
+        for (DAGEdge<Component, Dependency> e: graph.getOutgoingEdges()) {
             if (e.getLabel().getInitialDesire().equals(d) && e.getTail().getLabel().getSatisfaction().equals(s)) {
                 return e.getTail();
             }
@@ -1187,7 +1189,7 @@ public class DependencySolverTest {
         return null;
     }
     
-    private DAGNode<CachedSatisfaction, Dependency> getNode(DAGNode<CachedSatisfaction, Dependency> g, CachedSatisfaction s) {
+    private DAGNode<Component, Dependency> getNode(DAGNode<Component, Dependency> g, Component s) {
         return Iterables.find(g.getReachableNodes(),
                               DAGNode.labelMatches(Predicates.equalTo(s)),
                               null);

--- a/src/test/java/org/grouplens/grapht/solver/MockBindRule.java
+++ b/src/test/java/org/grouplens/grapht/solver/MockBindRule.java
@@ -18,7 +18,7 @@
  */
 package org.grouplens.grapht.solver;
 
-import org.grouplens.grapht.reflect.CachePolicy;
+import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.reflect.Desire;
 import org.grouplens.grapht.reflect.MockQualifierMatcher;
 import org.grouplens.grapht.reflect.QualifierMatcher;


### PR DESCRIPTION
This gives CachedSatisfaction a more implementation-agnostic name and location, so we can extend it in the future.
