### PR TITLE
Add skippable defaults

### DIFF
--- a/src/main/java/org/grouplens/grapht/Dependency.java
+++ b/src/main/java/org/grouplens/grapht/Dependency.java
@@ -73,7 +73,7 @@ public class Dependency implements Serializable {
 
     /**
      * Query whether this dependency is immune to rewriting.
-     * @return {@code true} if this dependency is immune to rewriting.
+     * @return {@code true} if this dependency cannot be rewritten during a graph rewrite.
      */
     public boolean isFixed() {
         return flags.contains(Flag.FIXED);

--- a/src/main/java/org/grouplens/grapht/Injector.java
+++ b/src/main/java/org/grouplens/grapht/Injector.java
@@ -19,6 +19,8 @@
  */
 package org.grouplens.grapht;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.inject.Qualifier;
 import java.lang.annotation.Annotation;
 
@@ -44,7 +46,6 @@ import java.lang.annotation.Annotation;
  */
 public interface Injector {
     /**
-     * <p>
      * Get an instance of T based on the bindings that this Injector was
      * configured with. An exception is thrown if the request type cannot be
      * instantiated with dependency injection.
@@ -58,10 +59,10 @@ public interface Injector {
      * @return An instance of type T
      * @throws ConstructionException if type cannot be instantiated
      */
+    @Nonnull
     <T> T getInstance(Class<T> type) throws InjectionException;
 
     /**
-     * <p>
      * Get an instance of T with the given {@link Qualifier} annotation.
      * 
      * @param <T> The object type
@@ -70,5 +71,19 @@ public interface Injector {
      * @return An instance of type T
      * @throws ConstructionException if type cannot be instantiated
      */
+    @Nonnull
     <T> T getInstance(Annotation qualifier, Class<T> type) throws InjectionException;
+
+    /**
+     * Try to get an instance of a component, returning {@code null} if the component
+     * does not have a configured implementation.
+     *
+     * @param qualifier The qualifier, or {@code null} for an unqualified component.
+     * @param type The component type.
+     * @param <T> The component type.
+     * @return An instance of type {@code T}, or {@code null} if no implemenation of {@code T} is configured.
+     * @throws InjectionException if there is some other error injecting the instance.
+     */
+    @Nullable
+    <T> T tryGetInstance(Annotation qualifier, Class<T> type) throws InjectionException;
 }

--- a/src/main/java/org/grouplens/grapht/annotation/DefaultImplementation.java
+++ b/src/main/java/org/grouplens/grapht/annotation/DefaultImplementation.java
@@ -26,13 +26,26 @@ import java.lang.annotation.*;
 
 /**
  * A default implementation for a {@link Qualifier}.
- * 
- * @author <a href="http://grouplens.org">GroupLens Research</a>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE })
 @Documented
 public @interface DefaultImplementation {
+    /**
+     * The implementation class.
+     * @return The implementation class.
+     */
     Class<?> value();
+
+    /**
+     * The default cache policy of this default.
+     * @return The default cache policy for this binding.
+     */
     CachePolicy cachePolicy() default CachePolicy.NO_PREFERENCE;
+
+    /**
+     * Whether the default binding should be skipped if its dependencies cannot be satisfied.
+     * @return {@code true} if this default should be skipped if its dependencies cannot be satisfied.
+     */
+    boolean skipIfUnusable() default false;
 }

--- a/src/main/java/org/grouplens/grapht/annotation/DefaultProvider.java
+++ b/src/main/java/org/grouplens/grapht/annotation/DefaultProvider.java
@@ -27,13 +27,22 @@ import java.lang.annotation.*;
 /**
  * DefaultProvider specifies a Provider implementation to act as a default binding
  * for types annotated with it.
- * 
- * @author <a href="http://grouplens.org">GroupLens Research</a>
  */
 @Documented
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DefaultProvider {
     Class<? extends Provider<?>> value();
+
+    /**
+     * The default cache policy of this default.
+     * @return The default cache policy for this binding.
+     */
     CachePolicy cachePolicy() default CachePolicy.NO_PREFERENCE;
+
+    /**
+     * Whether the default binding should be skipped if its dependencies cannot be satisfied.
+     * @return {@code true} if this default should be skipped if its dependencies cannot be satisfied.
+     */
+    boolean skipIfUnusable() default false;
 }

--- a/src/main/java/org/grouplens/grapht/solver/BindingFlag.java
+++ b/src/main/java/org/grouplens/grapht/solver/BindingFlag.java
@@ -22,11 +22,11 @@ package org.grouplens.grapht.solver;
 import java.util.EnumSet;
 
 /**
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ * Flags controlling binding behavior.
  */
 public enum BindingFlag {
     /**
-     * The binding is fixed (no its result cannot be rewritten).
+     * The binding is fixed (its result cannot be rewritten in graph rewriting).
      */
     FIXED,
     /**

--- a/src/main/java/org/grouplens/grapht/solver/BindingFlag.java
+++ b/src/main/java/org/grouplens/grapht/solver/BindingFlag.java
@@ -36,7 +36,11 @@ public enum BindingFlag {
     /**
      * The binding is terminal (no further rules should be applied).
      */
-    TERMINAL;
+    TERMINAL,
+    /**
+     * The binding should be skipped if one of its results' dependencies cannot be satisfied.
+     */
+    SKIPPABLE;
 
     public static EnumSet<BindingFlag> emptySet() {
         return EnumSet.noneOf(BindingFlag.class);

--- a/src/main/java/org/grouplens/grapht/solver/BindingResult.java
+++ b/src/main/java/org/grouplens/grapht/solver/BindingResult.java
@@ -101,6 +101,14 @@ public class BindingResult {
         return flags.contains(BindingFlag.TERMINAL);
     }
 
+    /**
+     * Query whether this binding result should be skipped when one of its dependencies fails.
+     * @return {@code true} if this binding result should be skipped if one of its dependencies fails.
+     */
+    public boolean isSkippable() {
+        return flags.contains(BindingFlag.SKIPPABLE);
+    }
+
     public static class Builder {
         private Desire desire;
         private CachePolicy policy;

--- a/src/main/java/org/grouplens/grapht/solver/DefaultDesireBindingFunction.java
+++ b/src/main/java/org/grouplens/grapht/solver/DefaultDesireBindingFunction.java
@@ -262,6 +262,11 @@ public class DefaultDesireBindingFunction implements BindingFunction {
                 }
             }
 
+            String skip = props.getProperty("skipIfUnusable");
+            if (skip != null && skip.trim().toLowerCase().equals("true")) {
+                builder.addFlag(BindingFlag.SKIPPABLE);
+            }
+
             if (found) {
                 String policy = props.getProperty("cachePolicy", "NO_PREFERENCE");
                 builder.setCachePolicy(CachePolicy.valueOf(policy));

--- a/src/main/java/org/grouplens/grapht/solver/DependencySolver.java
+++ b/src/main/java/org/grouplens/grapht/solver/DependencySolver.java
@@ -402,7 +402,11 @@ public class DependencySolver {
             Pair<DAGNode<Component, Dependency>, Dependency> dep;
             try {
                 dep = resolveFully(d, newContext, deferQueue);
-            } catch (ResolutionException ex) {
+            } catch (UnresolvableDependencyException ex) {
+                if (!d.equals(ex.getDesireChain().getInitialDesire())) {
+                    // this is for some other (deeper) desire, fail
+                    throw ex;
+                }
                 // whoops, try to backtrack
                 Resolution back = result.skippable ? result.backtrack() : null;
                 if (back != null) {

--- a/src/main/java/org/grouplens/grapht/solver/DesireChain.java
+++ b/src/main/java/org/grouplens/grapht/solver/DesireChain.java
@@ -94,6 +94,19 @@ public class DesireChain extends AbstractChain<Desire> {
     }
 
     /**
+     * Return the desire chain up to, but not including, the current desire.
+     * @return The previous desire chain.
+     */
+    @Nonnull
+    public DesireChain getPreviousDesireChain() {
+        if (previous == null) {
+            throw new IllegalArgumentException("cannot get previous chain from singleton");
+        } else {
+            return (DesireChain) previous;
+        }
+    }
+
+    /**
      * Get this chain's key. Each chain has a key, a unique object that is created when the chain
      * is created (via {@link #singleton(org.grouplens.grapht.reflect.Desire)}), and preserved through
      * {@link #extend(org.grouplens.grapht.reflect.Desire)} operations.  It can be used to remember

--- a/src/main/java/org/grouplens/grapht/solver/InjectionContext.java
+++ b/src/main/java/org/grouplens/grapht/solver/InjectionContext.java
@@ -52,6 +52,21 @@ public class InjectionContext extends AbstractChain<Pair<Satisfaction,InjectionP
     }
 
     /**
+     * Extend or create an injection context.
+     * @param prefix The initial context.
+     * @param satisfaction The satisfaction.
+     * @param ip The injection point.
+     * @return The injection context.
+     */
+    public static InjectionContext extend(@Nullable InjectionContext prefix, Satisfaction satisfaction, InjectionPoint ip) {
+        if (prefix == null) {
+            return singleton(satisfaction, ip);
+        } else {
+            return prefix.extend(satisfaction, ip);
+        }
+    }
+
+    /**
      * Construct a singleton injection context with no attributes.
      * @param satisfaction The satisfaction.
      * @return The injection context.

--- a/src/main/java/org/grouplens/grapht/solver/UnresolvableDependencyException.java
+++ b/src/main/java/org/grouplens/grapht/solver/UnresolvableDependencyException.java
@@ -44,13 +44,25 @@ public class UnresolvableDependencyException extends ResolutionException {
     }
     
     /**
+     * Get the context for this error.
+     *
      * @return The context that produced the unresolvable desire
      */
     public InjectionContext getContext() {
         return context;
     }
+
+    /**
+     * Get the entire desire chain in which resolution failed.
+     * @return The desire chain that failed to resolve.
+     */
+    public DesireChain getDesireChain() {
+        return desires;
+    }
     
     /**
+     * Get the desire that failed to resolve.
+     *
      * @return The unresolvable desire
      */
     public Desire getDesire() {

--- a/src/test/java/org/grouplens/grapht/SkipIfUnusableTest.java
+++ b/src/test/java/org/grouplens/grapht/SkipIfUnusableTest.java
@@ -76,7 +76,7 @@ public class SkipIfUnusableTest {
         bld.bind(Inner.class).to(InnerWithDep.class);
         Injector inj = bld.build();
         try {
-            IfaceWithSkippableDefault obj = inj.getInstance(IfaceWithSkippableDefault.class);
+            inj.tryGetInstance(null, IfaceWithSkippableDefault.class);
             fail("injecting a skippable default with a satisfied but instantiable dep should fail");
         } catch (InjectionException ex) {
             assertThat(ex, instanceOf(UnresolvableDependencyException.class));
@@ -91,7 +91,7 @@ public class SkipIfUnusableTest {
         InjectorBuilder bld = InjectorBuilder.create();
         Injector inj = bld.build();
         try {
-            inj.getInstance(DefaultRequirer.class);
+            inj.getInstance(null, DefaultRequirer.class);
             fail("injection of dep on skipped default should fail");
         } catch (InjectionException ex) {
             assertThat(ex, instanceOf(UnresolvableDependencyException.class));
@@ -110,6 +110,22 @@ public class SkipIfUnusableTest {
             assertThat(obj, notNullValue());
         } catch (InjectionException ex) {
             fail("injection of component with optional dep on skipped default should succeed");
+        }
+    }
+
+    /**
+     * Injection of component that optionally uses a non-skipped but transitively non-instantiable default should fail.
+     */
+    @Test
+    public void testFailOptionalDepHasUnmetDep() {
+        InjectorBuilder bld = InjectorBuilder.create();
+        bld.bind(Inner.class).to(InnerWithDep.class);
+        Injector inj = bld.build();
+        try {
+            OptionalDefaultRequirer obj = inj.getInstance(OptionalDefaultRequirer.class);
+            fail("injection of component with optional dep on non-skipped but uninstantiable default should fail");
+        } catch (InjectionException ex) {
+            assertThat(ex, instanceOf(UnresolvableDependencyException.class));
         }
     }
 

--- a/src/test/java/org/grouplens/grapht/SkipIfUnusableTest.java
+++ b/src/test/java/org/grouplens/grapht/SkipIfUnusableTest.java
@@ -45,7 +45,7 @@ public class SkipIfUnusableTest {
         InjectorBuilder bld = InjectorBuilder.create();
         Injector inj = bld.build();
         try {
-            IfaceWithSkippableDefault obj = inj.getInstance(IfaceWithSkippableDefault.class);
+            IfaceWithSkippableDefault obj = inj.tryGetInstance(null, IfaceWithSkippableDefault.class);
             assertThat(obj, nullValue());
         } catch (InjectionException ex) {
             fail("injection of skipped object should succeed with null object");
@@ -60,7 +60,7 @@ public class SkipIfUnusableTest {
         InjectorBuilder bld = InjectorBuilder.create();
         Injector inj = bld.build();
         try {
-            IfaceWithSkippableDefaultProvider obj = inj.getInstance(IfaceWithSkippableDefaultProvider.class);
+            IfaceWithSkippableDefaultProvider obj = inj.tryGetInstance(null, IfaceWithSkippableDefaultProvider.class);
             assertThat(obj, nullValue());
         } catch (InjectionException e) {
             fail("injection of skipped provider should succeed with null object");

--- a/src/test/java/org/grouplens/grapht/SkipIfUnusableTest.java
+++ b/src/test/java/org/grouplens/grapht/SkipIfUnusableTest.java
@@ -1,3 +1,22 @@
+/*
+ * Grapht, an open source dependency injector.
+ * Copyright 2014-2015 various contributors (see CONTRIBUTORS.txt)
+ * Copyright 2010-2014 Regents of the University of Minnesota
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.grouplens.grapht;
 
 import org.grouplens.grapht.annotation.DefaultImplementation;

--- a/src/test/java/org/grouplens/grapht/SkipIfUnusableTest.java
+++ b/src/test/java/org/grouplens/grapht/SkipIfUnusableTest.java
@@ -1,0 +1,240 @@
+package org.grouplens.grapht;
+
+import org.grouplens.grapht.annotation.DefaultImplementation;
+import org.grouplens.grapht.annotation.DefaultProvider;
+import org.grouplens.grapht.solver.UnresolvableDependencyException;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class SkipIfUnusableTest {
+    /**
+     * A skippable default with satisfied dependencies should be injected.
+     */
+    @Test
+    public void testSatisfyImplementation() throws InjectionException {
+        InjectorBuilder bld = InjectorBuilder.create();
+        bld.bind(Inner.class).to(InnerObj.class);
+        Injector inj = bld.build();
+        IfaceWithSkippableDefault obj = inj.getInstance(IfaceWithSkippableDefault.class);
+        assertThat(obj, instanceOf(DftImpl.class));
+    }
+
+    /**
+     * A skippable default provider with satisfied dependencies should be injected.
+     */
+    @Test
+    public void testSatisfyProvider() throws InjectionException {
+        InjectorBuilder bld = InjectorBuilder.create();
+        bld.bind(Inner.class).to(InnerObj.class);
+        Injector inj = bld.build();
+        IfaceWithSkippableDefaultProvider obj = inj.getInstance(IfaceWithSkippableDefaultProvider.class);
+        assertThat(obj, instanceOf(ProvidedImpl.class));
+    }
+
+    /**
+     * A skippable default without satisfied dependencies should not be injected.
+     */
+    @Test
+    public void testSkipImplementation() {
+        InjectorBuilder bld = InjectorBuilder.create();
+        Injector inj = bld.build();
+        try {
+            IfaceWithSkippableDefault obj = inj.getInstance(IfaceWithSkippableDefault.class);
+            assertThat(obj, nullValue());
+        } catch (InjectionException ex) {
+            fail("injection of skipped object should succeed with null object");
+        }
+    }
+
+    /**
+     * A skippable default provider without satisfied dependencies should not be injected.
+     */
+    @Test
+    public void testSkipProvider() {
+        InjectorBuilder bld = InjectorBuilder.create();
+        Injector inj = bld.build();
+        try {
+            IfaceWithSkippableDefaultProvider obj = inj.getInstance(IfaceWithSkippableDefaultProvider.class);
+            assertThat(obj, nullValue());
+        } catch (InjectionException e) {
+            fail("injection of skipped provider should succeed with null object");
+        }
+    }
+
+    /**
+     * A skippable default with a satisfied dependency that itself has an unsatisfied dependency should fail.
+     */
+    @Test
+    public void testFailWithUnsatisfiedTransitiveDep() {
+        InjectorBuilder bld = InjectorBuilder.create();
+        bld.bind(Inner.class).to(InnerWithDep.class);
+        Injector inj = bld.build();
+        try {
+            IfaceWithSkippableDefault obj = inj.getInstance(IfaceWithSkippableDefault.class);
+            fail("injecting a skippable default with a satisfied but instantiable dep should fail");
+        } catch (InjectionException ex) {
+            assertThat(ex, instanceOf(UnresolvableDependencyException.class));
+        }
+    }
+
+    /**
+     * Injection of component that depends on a skipped default should fail.
+     */
+    @Test
+    public void testFailWithUnusableDefaultForDep() {
+        InjectorBuilder bld = InjectorBuilder.create();
+        Injector inj = bld.build();
+        try {
+            inj.getInstance(DefaultRequirer.class);
+            fail("injection of dep on skipped default should fail");
+        } catch (InjectionException ex) {
+            assertThat(ex, instanceOf(UnresolvableDependencyException.class));
+        }
+    }
+
+    /**
+     * Injection of component that optionally uses a skipped default should succeed.
+     */
+    @Test
+    public void testAcceptSkippedOptionalDep() {
+        InjectorBuilder bld = InjectorBuilder.create();
+        Injector inj = bld.build();
+        try {
+            OptionalDefaultRequirer obj = inj.getInstance(OptionalDefaultRequirer.class);
+            assertThat(obj, notNullValue());
+        } catch (InjectionException ex) {
+            fail("injection of component with optional dep on skipped default should succeed");
+        }
+    }
+
+    /**
+     * Interface for dependencies.
+     */
+    interface Inner {
+    }
+
+    /**
+     * Implementation of dependency interface.
+     */
+    static class InnerObj implements Inner {
+        @Inject
+        public InnerObj() {}
+    }
+
+    /**
+     * Implementation of dependency with a dependency.
+     */
+    static class InnerWithDep implements Inner {
+        private final String message;
+
+        @Inject
+        public InnerWithDep(String msg) {
+            message = msg;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    /**
+     * Interface with a default that is skippable.
+     */
+    @DefaultImplementation(value=DftImpl.class, skipIfUnusable = true)
+    interface IfaceWithSkippableDefault {
+        Inner getInner();
+    }
+
+    /**
+     * Default implementation of the skippable interface.
+     */
+    static class DftImpl implements IfaceWithSkippableDefault {
+        private final Inner inner;
+
+        @Inject
+        public DftImpl(Inner in) {
+            inner = in;
+        }
+
+        @Override
+        public Inner getInner() {
+            return inner;
+        }
+    }
+
+    /**
+     * Interface with a default provider that is skippable.
+     */
+    @DefaultProvider(value=DftProvider.class, skipIfUnusable = true)
+    interface IfaceWithSkippableDefaultProvider {
+        Inner getInner();
+    }
+
+    /**
+     * Default provider for the skippable interface.
+     */
+    static class DftProvider implements Provider<IfaceWithSkippableDefaultProvider> {
+        private final Inner inner;
+
+        @Inject
+        public DftProvider(Inner in) {
+            inner = in;
+        }
+
+        @Override
+        public IfaceWithSkippableDefaultProvider get() {
+            return new ProvidedImpl(inner);
+        }
+    }
+
+    static class ProvidedImpl implements IfaceWithSkippableDefaultProvider {
+        private final Inner inner;
+
+        public ProvidedImpl(Inner in) {
+            inner = in;
+        }
+
+        @Override
+        public Inner getInner() {
+            return inner;
+        }
+    }
+
+    /**
+     * A component that requires an object with one of our skippable defaults.
+     */
+    static class DefaultRequirer {
+        private final IfaceWithSkippableDefault dependency;
+
+        @Inject
+        public DefaultRequirer(IfaceWithSkippableDefault dep) {
+            dependency = dep;
+        }
+
+        public IfaceWithSkippableDefault getDependency() {
+            return dependency;
+        }
+    }
+
+    /**
+     * A component that optionally uses an object with one of our skippable defaults.
+     */
+    static class OptionalDefaultRequirer {
+        private final IfaceWithSkippableDefault dependency;
+
+        @Inject
+        public OptionalDefaultRequirer(@Nullable IfaceWithSkippableDefault dep) {
+            dependency = dep;
+        }
+
+        public IfaceWithSkippableDefault getDependency() {
+            return dependency;
+        }
+    }
+}


### PR DESCRIPTION
This adds a new flag, `skipIfUnusable`, to default specifications that instructs Grapht to skip that default binding if one of its direct dependencies cannot be resolved. If the direct dependencies can be resolved, but one of *their* dependencies fails, the injection fails as if the skippable default were not skippable. Skippable defaults will *usually* fall back to a `null`.

There are some limitations so far:

- This plays very badly with deferred dependencies.
- It does not look for other bindings if the skippable binding cannot be used; rather, it just backtracks to the previous binding. Also, it just backtracks once, so if you have a binding to a non-instantiable interface, which is then defaulted with a skippable binding, the skip won't work.
- The behavior on transitive dependency failures could perhaps use review — do we want transitive dependency failures to cause a skip rather than a failure?

Includes pretty full tests, except for the skip flag appearing in META-INF defaults.