### PR TITLE
Improvements for lifecycle handling

### DIFF
--- a/src/main/java/org/grouplens/grapht/InjectionContainer.java
+++ b/src/main/java/org/grouplens/grapht/InjectionContainer.java
@@ -116,7 +116,7 @@ public class InjectionContainer {
 
             Map<Desire, Instantiator> depMap = makeDependencyMap(node, backEdges);
 
-            Instantiator raw = node.getLabel().getSatisfaction().makeInstantiator(depMap, this);
+            Instantiator raw = node.getLabel().getSatisfaction().makeInstantiator(depMap, manager);
 
             CachePolicy policy = node.getLabel().getCachePolicy();
             if (policy.equals(CachePolicy.NO_PREFERENCE)) {

--- a/src/main/java/org/grouplens/grapht/InjectionContainer.java
+++ b/src/main/java/org/grouplens/grapht/InjectionContainer.java
@@ -46,12 +46,12 @@ import java.util.*;
  * @since 0.9
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
-public class InjectionContainer implements AutoCloseable {
+public class InjectionContainer {
     private static final Logger logger = LoggerFactory.getLogger(InjectionContainer.class);
 
     private final CachePolicy defaultCachePolicy;
     private final Map<DAGNode<Component, Dependency>, Instantiator> providerCache;
-    private final Deque registry = new LinkedList();
+    private final LifecycleManager manager;
 
     /**
      * Create a new instantiator with a default policy of {@code MEMOIZE}.
@@ -62,17 +62,28 @@ public class InjectionContainer implements AutoCloseable {
     }
 
     /**
-     * Create a new instantiator.
+     * Create a new instantiator without a lifecycle manager.
      * @param dft The default cache policy.
      * @return The instantiator.
      */
     public static InjectionContainer create(CachePolicy dft) {
-        return new InjectionContainer(dft);
+        return new InjectionContainer(dft, null);
     }
 
-    private InjectionContainer(CachePolicy dft) {
+    /**
+     * Create a new instantiator.
+     * @param dft The default cache policy.
+     * @param mgr The lifecycle manager.
+     * @return The instantiator.
+     */
+    public static InjectionContainer create(CachePolicy dft, LifecycleManager mgr) {
+        return new InjectionContainer(dft, mgr);
+    }
+
+    private InjectionContainer(CachePolicy dft, LifecycleManager mgr) {
         defaultCachePolicy = dft;
         providerCache = new WeakHashMap<DAGNode<Component, Dependency>, Instantiator>();
+        manager = mgr;
     }
 
     /**
@@ -141,43 +152,13 @@ public class InjectionContainer implements AutoCloseable {
         return Maps.asMap(desires.build(), new DepLookup(edges, backEdges));
     }
 
-    public void registerComponent(Object instance){
-        registry.push(instance);
-    }
-
-    @Override
-    public void close() {
-        Throwable throwable =  null;
-        while (!registry.isEmpty()) {
-            Object component = registry.pop();
-                if(component instanceof AutoCloseable) {
-                    try {
-                        ((AutoCloseable)component).close();
-                    } catch (Throwable e) {
-                        if(throwable == null) {
-                            throwable = e;
-                        } else {
-                            throwable.addSuppressed(e);
-                        }
-                    }
-                }
-            Method[] methods = MethodUtils.getMethodsWithAnnotation(component.getClass(), PreDestroy.class);
-            for(Method method:methods) {
-                method.setAccessible(true);
-                try {
-                    method.invoke(component);
-                } catch (Throwable e) {
-                    if(throwable == null) {
-                        throwable = e;
-                    } else {
-                        throwable.addSuppressed(e);
-                    }
-                }
-            }
-        }
-        if(throwable!=null) {
-          throw Throwables.propagate(throwable);
-        }
+    /**
+     * Get the lifecycle manager for this container.
+     * @return The lifecycle manager for the container.
+     */
+    @Nullable
+    public LifecycleManager getLifecycleManager() {
+        return manager;
     }
 
     /**

--- a/src/main/java/org/grouplens/grapht/LifecycleManager.java
+++ b/src/main/java/org/grouplens/grapht/LifecycleManager.java
@@ -1,0 +1,107 @@
+package org.grouplens.grapht;
+
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PreDestroy;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Deque;
+import java.util.LinkedList;
+
+public class LifecycleManager implements AutoCloseable {
+    private static final Logger logger = LoggerFactory.getLogger(LifecycleManager.class);
+    private Deque<TeardownAction> actions = new LinkedList<TeardownAction>();
+
+    /**
+     * Register a component with the lifecycle manager.  The component will be torn down when the lifecycle manager
+     * is closed, using whatever teardown the lifecycle manager institutes.
+     *
+     * @param instance The component to register.
+     */
+    public void registerComponent(Object instance) {
+        if (instance == null) {
+            return;
+        }
+
+        if (instance instanceof AutoCloseable) {
+            actions.add(new CloseAction((AutoCloseable) instance));
+        }
+        for (Method m: MethodUtils.getMethodsListWithAnnotation(instance.getClass(), PreDestroy.class)) {
+            actions.add(new PreDestroyAction(instance, m));
+        }
+    }
+
+    /**
+     * Close the lifecycle manager, shutting down all components it manages.
+     */
+    @Override
+    public void close() {
+        Throwable error = null;
+        while (!actions.isEmpty()) {
+            TeardownAction action = actions.removeFirst();
+            try {
+                action.destroy();
+            } catch (Throwable th) {
+                if (error == null) {
+                    error = th;
+                } else {
+                    error.addSuppressed(th);
+                }
+            }
+        }
+        if (error != null) {
+            throw Throwables.propagate(error);
+        }
+    }
+
+    /**
+     * Interface for actions that tear down components.
+     */
+    interface TeardownAction {
+        void destroy();
+    }
+
+    static class PreDestroyAction implements TeardownAction {
+        private final Object instance;
+        private final Method method;
+
+        public PreDestroyAction(Object inst, Method m) {
+            instance = inst;
+            method = m;
+        }
+
+        @Override
+        public void destroy() {
+            try {
+                logger.debug("invoking pre-destroy method {} on {}", method, instance);
+                method.invoke(instance);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException("cannot access " + method, e);
+            } catch (InvocationTargetException e) {
+                throw new UncheckedExecutionException("error invoking " + method, e);
+            }
+        }
+    }
+
+    static class CloseAction implements TeardownAction {
+        private final AutoCloseable instance;
+
+        public CloseAction(AutoCloseable inst) {
+            instance = inst;
+        }
+
+        @Override
+        public void destroy() {
+            try {
+                logger.debug("closing {}", instance);
+                instance.close();
+            } catch (Exception e) {
+                throw new UncheckedExecutionException("Error destroying " + instance, e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/grouplens/grapht/LifecycleManager.java
+++ b/src/main/java/org/grouplens/grapht/LifecycleManager.java
@@ -1,3 +1,22 @@
+/*
+ * Grapht, an open source dependency injector.
+ * Copyright 2014-2015 various contributors (see CONTRIBUTORS.txt)
+ * Copyright 2010-2014 Regents of the University of Minnesota
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.grouplens.grapht;
 
 import com.google.common.base.Throwables;

--- a/src/main/java/org/grouplens/grapht/reflect/Satisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/Satisfaction.java
@@ -19,11 +19,10 @@
  */
 package org.grouplens.grapht.reflect;
 
-import org.grouplens.grapht.CachePolicy;
-import org.grouplens.grapht.InjectionContainer;
-import org.grouplens.grapht.Injector;
-import org.grouplens.grapht.Instantiator;
+import org.grouplens.grapht.*;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import java.io.Serializable;
 import java.lang.reflect.Type;
@@ -111,9 +110,11 @@ public interface Satisfaction extends Serializable {
      * 
      * @param dependencies A function mapping desires to providers of their
      *            instances.
+     * @param lm The lifecycle manager (if one should be used).
      * @return An instantiator of new instances of the type specified by this
      *         satisfaction, instantiated using the specified dependency
      *         mapping.
      */
-    Instantiator makeInstantiator(Map<Desire,Instantiator> dependencies, InjectionContainer container);
+    Instantiator makeInstantiator(@Nonnull Map<Desire,Instantiator> dependencies,
+                                  @Nullable LifecycleManager lm);
 }

--- a/src/main/java/org/grouplens/grapht/reflect/internal/ClassSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/ClassSatisfaction.java
@@ -20,8 +20,8 @@
 package org.grouplens.grapht.reflect.internal;
 
 import org.grouplens.grapht.CachePolicy;
-import org.grouplens.grapht.InjectionContainer;
 import org.grouplens.grapht.Instantiator;
+import org.grouplens.grapht.LifecycleManager;
 import org.grouplens.grapht.reflect.Desire;
 import org.grouplens.grapht.reflect.Satisfaction;
 import org.grouplens.grapht.reflect.SatisfactionVisitor;
@@ -102,8 +102,8 @@ public class ClassSatisfaction implements Satisfaction, Serializable {
 
     @Override
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Instantiator makeInstantiator(Map<Desire,Instantiator> dependencies, InjectionContainer container) {
-        return new ClassInstantiator(type, getDependencies(), dependencies, container.getLifecycleManager());
+    public Instantiator makeInstantiator(Map<Desire,Instantiator> dependencies, LifecycleManager lm) {
+        return new ClassInstantiator(type, getDependencies(), dependencies, lm);
     }
     
     @Override

--- a/src/main/java/org/grouplens/grapht/reflect/internal/ClassSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/ClassSatisfaction.java
@@ -103,7 +103,7 @@ public class ClassSatisfaction implements Satisfaction, Serializable {
     @Override
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public Instantiator makeInstantiator(Map<Desire,Instantiator> dependencies, InjectionContainer container) {
-        return new ClassInstantiator(type, getDependencies(), dependencies, container);
+        return new ClassInstantiator(type, getDependencies(), dependencies, container.getLifecycleManager());
     }
     
     @Override

--- a/src/main/java/org/grouplens/grapht/reflect/internal/InstanceSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/InstanceSatisfaction.java
@@ -19,10 +19,7 @@
  */
 package org.grouplens.grapht.reflect.internal;
 
-import org.grouplens.grapht.CachePolicy;
-import org.grouplens.grapht.InjectionContainer;
-import org.grouplens.grapht.Instantiator;
-import org.grouplens.grapht.Instantiators;
+import org.grouplens.grapht.*;
 import org.grouplens.grapht.reflect.Desire;
 import org.grouplens.grapht.reflect.Satisfaction;
 import org.grouplens.grapht.reflect.SatisfactionVisitor;
@@ -97,7 +94,7 @@ public class InstanceSatisfaction implements Satisfaction, Serializable {
     @Override
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public Instantiator makeInstantiator(Map<Desire,Instantiator> dependencies,
-                                         InjectionContainer injectionContainer) {
+                                         LifecycleManager injectionContainer) {
         return Instantiators.ofInstance(instance);
     }
     

--- a/src/main/java/org/grouplens/grapht/reflect/internal/NullSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/NullSatisfaction.java
@@ -19,10 +19,7 @@
  */
 package org.grouplens.grapht.reflect.internal;
 
-import org.grouplens.grapht.CachePolicy;
-import org.grouplens.grapht.InjectionContainer;
-import org.grouplens.grapht.Instantiator;
-import org.grouplens.grapht.Instantiators;
+import org.grouplens.grapht.*;
 import org.grouplens.grapht.reflect.Desire;
 import org.grouplens.grapht.reflect.Satisfaction;
 import org.grouplens.grapht.reflect.SatisfactionVisitor;
@@ -97,7 +94,7 @@ public class
     @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public Instantiator makeInstantiator(Map<Desire,Instantiator> dependencies,
-                                         InjectionContainer container) {
+                                         LifecycleManager lm) {
         return Instantiators.ofNull(type);
     }
     

--- a/src/main/java/org/grouplens/grapht/reflect/internal/ProviderClassSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/ProviderClassSatisfaction.java
@@ -115,7 +115,7 @@ public class ProviderClassSatisfaction implements Satisfaction, Serializable {
         // we have to use the raw type because we don't have enough information,
         // but we can assume correctly that it will build a provider
         ClassInstantiator providerBuilder = new ClassInstantiator(providerType, getDependencies(),
-                                                                  dependencies, container);
+                                                                  dependencies, container.getLifecycleManager());
         return Instantiators.ofProviderInstantiator(providerBuilder);
     }
     

--- a/src/main/java/org/grouplens/grapht/reflect/internal/ProviderClassSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/ProviderClassSatisfaction.java
@@ -19,10 +19,7 @@
  */
 package org.grouplens.grapht.reflect.internal;
 
-import org.grouplens.grapht.CachePolicy;
-import org.grouplens.grapht.InjectionContainer;
-import org.grouplens.grapht.Instantiator;
-import org.grouplens.grapht.Instantiators;
+import org.grouplens.grapht.*;
 import org.grouplens.grapht.reflect.*;
 import org.grouplens.grapht.util.ClassProxy;
 import org.grouplens.grapht.util.Preconditions;
@@ -111,11 +108,11 @@ public class ProviderClassSatisfaction implements Satisfaction, Serializable {
     @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public Instantiator makeInstantiator(Map<Desire,Instantiator> dependencies,
-                                         InjectionContainer container) {
+                                         LifecycleManager lm) {
         // we have to use the raw type because we don't have enough information,
         // but we can assume correctly that it will build a provider
         ClassInstantiator providerBuilder = new ClassInstantiator(providerType, getDependencies(),
-                                                                  dependencies, container.getLifecycleManager());
+                                                                  dependencies, lm);
         return Instantiators.ofProviderInstantiator(providerBuilder);
     }
     

--- a/src/main/java/org/grouplens/grapht/reflect/internal/ProviderInstanceSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/ProviderInstanceSatisfaction.java
@@ -19,10 +19,7 @@
  */
 package org.grouplens.grapht.reflect.internal;
 
-import org.grouplens.grapht.CachePolicy;
-import org.grouplens.grapht.InjectionContainer;
-import org.grouplens.grapht.Instantiator;
-import org.grouplens.grapht.Instantiators;
+import org.grouplens.grapht.*;
 import org.grouplens.grapht.reflect.*;
 import org.grouplens.grapht.util.Preconditions;
 import org.grouplens.grapht.util.Types;
@@ -39,7 +36,7 @@ import java.util.Map;
 /**
  * Satisfaction implementation wrapping an existing Provider instance. It has no
  * dependencies and it always returns the same Provider when
- * {@link #makeInstantiator(Map,InjectionContainer)} is invoked.
+ * {@link Satisfaction#makeInstantiator(Map, LifecycleManager)} is invoked.
  * 
  * @author <a href="http://grouplens.org">GroupLens Research</a>
  */
@@ -64,7 +61,7 @@ public class ProviderInstanceSatisfaction implements Satisfaction, Serializable 
     }
     
     /**
-     * @return The provider instance returned by {@link #makeInstantiator(Map, InjectionContainer)}
+     * @return The provider instance returned by {@link Satisfaction#makeInstantiator(Map, LifecycleManager)}
      */
     public Provider<?> getProvider() {
         return provider;
@@ -97,7 +94,7 @@ public class ProviderInstanceSatisfaction implements Satisfaction, Serializable 
 
     @Override
     public Instantiator makeInstantiator(Map<Desire,Instantiator> dependencies,
-                                         InjectionContainer container) {
+                                         LifecycleManager lm) {
         return Instantiators.ofProvider(provider);
     }
     

--- a/src/main/java/org/grouplens/grapht/solver/DefaultInjector.java
+++ b/src/main/java/org/grouplens/grapht/solver/DefaultInjector.java
@@ -49,6 +49,8 @@ public class DefaultInjector implements Injector {
     
     private final DependencySolver solver;
     private final InjectionContainer instantiator;
+    private final LifecycleManager manager;
+
     /**
      * <p>
      * Create a new DefaultInjector. The created resolver will use a max
@@ -109,7 +111,8 @@ public class DefaultInjector implements Injector {
                                  .addBindingFunctions(functions)
                                  .setMaxDepth(maxDepth)
                                  .build();
-        instantiator = InjectionContainer.create(defaultPolicy);
+        manager = new LifecycleManager();
+        instantiator = InjectionContainer.create(defaultPolicy, manager);
     }
     
     /**
@@ -169,6 +172,8 @@ public class DefaultInjector implements Injector {
 
     @Override
     public void close() {
-        instantiator.close();
+        if (manager != null) {
+            manager.close();
+        }
     }
 }

--- a/src/main/java/org/grouplens/grapht/solver/ProviderBindingFunction.java
+++ b/src/main/java/org/grouplens/grapht/solver/ProviderBindingFunction.java
@@ -134,7 +134,7 @@ public class ProviderBindingFunction implements BindingFunction {
 
         @Override
         public Instantiator makeInstantiator(Map<Desire,Instantiator> dependencies,
-                                             InjectionContainer container) {
+                                             LifecycleManager lm) {
             Instantiator instantiator = dependencies.get(providedDesire);
             
             // Inject an instance of a provider wrapping this instantiator.

--- a/src/test/java/org/grouplens/grapht/reflect/MockSatisfaction.java
+++ b/src/test/java/org/grouplens/grapht/reflect/MockSatisfaction.java
@@ -19,10 +19,7 @@
  */
 package org.grouplens.grapht.reflect;
 
-import org.grouplens.grapht.CachePolicy;
-import org.grouplens.grapht.InjectionContainer;
-import org.grouplens.grapht.Instantiator;
-import org.grouplens.grapht.Instantiators;
+import org.grouplens.grapht.*;
 
 import javax.inject.Provider;
 import java.lang.reflect.Type;
@@ -34,7 +31,7 @@ import java.util.Map;
 /**
  * MockSatisfaction is a simple implementation of Satisfactions for certain
  * types of test cases. It can be configured by its constructors, although
- * {@link #makeInstantiator(Map, InjectionContainer)} always returns the same provider.
+ * {@link Satisfaction#makeInstantiator(Map, LifecycleManager)} always returns the same provider.
  * 
  * @author <a href="http://grouplens.org">GroupLens Research</a>
  */
@@ -99,7 +96,7 @@ public class MockSatisfaction implements Satisfaction {
 
     @Override
     public Instantiator makeInstantiator(Map<Desire,Instantiator> dependencies,
-                                         InjectionContainer container) {
+                                         LifecycleManager lm) {
         return Instantiators.ofProvider(provider);
     }
 

--- a/src/test/java/org/grouplens/grapht/reflect/internal/SatisfactionTest.java
+++ b/src/test/java/org/grouplens/grapht/reflect/internal/SatisfactionTest.java
@@ -20,8 +20,6 @@
 package org.grouplens.grapht.reflect.internal;
 
 import com.google.common.collect.Maps;
-import org.grouplens.grapht.CachePolicy;
-import org.grouplens.grapht.InjectionContainer;
 import org.grouplens.grapht.Instantiator;
 import org.grouplens.grapht.Instantiators;
 import org.grouplens.grapht.reflect.Desire;
@@ -92,8 +90,7 @@ public class SatisfactionTest {
         providers.put(new ReflectionDesire(TypeC.INTERFACE_B), Instantiators.ofInstance(b1));
         providers.put(new ReflectionDesire(TypeC.TYPE_B), Instantiators.ofInstance(b2));
         
-        Instantiator provider = new ClassSatisfaction(TypeC.class).makeInstantiator(providers,
-                                                                                    InjectionContainer.create());
+        Instantiator provider = new ClassSatisfaction(TypeC.class).makeInstantiator(providers, null);
         Object o = provider.instantiate();
         
         Assert.assertTrue(o instanceof TypeC);
@@ -120,7 +117,7 @@ public class SatisfactionTest {
         TypeC c = new TypeC(4);
 
         Instantiator p = new InstanceSatisfaction(c).makeInstantiator(Collections.EMPTY_MAP,
-                                                                      InjectionContainer.create());
+                                                                      null);
         Assert.assertSame(c, p.instantiate());
     }
     
@@ -136,9 +133,7 @@ public class SatisfactionTest {
     public void testProviderClassSatisfactionProvider() throws Exception {
         Map<Desire,Instantiator> providers = Maps.newHashMap();
         providers.put(new ReflectionDesire(ctorProviderCIP), Instantiators.ofInstance(10));
-        Instantiator provider = new ProviderClassSatisfaction(ProviderC.class).makeInstantiator(providers,
-                                                                                                InjectionContainer.
-                                                                                                create());
+        Instantiator provider = new ProviderClassSatisfaction(ProviderC.class).makeInstantiator(providers, null);
         // Assert.assertTrue(provider instanceof ProviderC);
         
         TypeC c = (TypeC) provider.instantiate();


### PR DESCRIPTION
This works on #122, by using shutdown actions, and #121, by moving the lifecycle manager to a separate component.

`@PostConstruct` actions are still run even if the lifecycle manager is not in use.