### PR TITLE
Don't catch Throwable in instantiators

### DIFF
--- a/src/main/java/org/grouplens/grapht/Instantiators.java
+++ b/src/main/java/org/grouplens/grapht/Instantiators.java
@@ -24,10 +24,10 @@ import com.google.common.base.Throwables;
 import org.grouplens.grapht.util.LogContext;
 import org.grouplens.grapht.util.TypedProvider;
 import org.grouplens.grapht.util.Types;
-import javax.inject.Provider;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
-import org.grouplens.grapht.util.LogContext;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Provider;
 
 /**
  * Utilities and methods for building and working with {@link org.grouplens.grapht.Instantiator}s.
@@ -151,7 +151,7 @@ public final class Instantiators {
             try {
                 mdcContextProvider.put("org.grouplens.grapht.currentProvider", provider.toString());
                 return provider.get();
-            } catch (Throwable th) {
+            } catch (Exception th) {
                 throw new ConstructionException(getType(), "Error invoking provider " + providerInstantiator, th);
             } finally {
                 mdcContextProvider.finish();
@@ -182,7 +182,7 @@ public final class Instantiators {
                     if (!instantiated) {
                         try {
                             instance = delegate.instantiate();
-                        } catch (Throwable th) {
+                        } catch (Exception th) {
                             error = th;
                         }
                         instantiated = true;

--- a/src/main/java/org/grouplens/grapht/LifecycleManager.java
+++ b/src/main/java/org/grouplens/grapht/LifecycleManager.java
@@ -57,6 +57,7 @@ public class LifecycleManager implements AutoCloseable {
     /**
      * Close the lifecycle manager, shutting down all components it manages.
      */
+    @SuppressWarnings("squid:S1181") // catch Throwable - OK b/c we use it for ensuring cleanup
     @Override
     public void close() {
         Throwable error = null;


### PR DESCRIPTION
Right now, `Instantiator`s catch `Throwable` for re-wrapping in `ConstructionException`, which includes internal VM errors. 

This PR changes that to only catch & wrap `Exception`, so out-of-memory and other internal thread errors are propagated unchanged.  General wisdom seems to be that `Throwable` should only caught in very limited circumstances, and I am unpersuaded that this counts as one of them. Would love @lhkbob's take.

One other instance of catching `Throwable` — in `LifecycleManager` — I am keeping, as its purpose is to make sure all cleanup actions are run; it chains the errors and rethrows, possibly as a chain of suppressed exceptions.
