### PR TITLE
Clean up Critical SonarQube warnings

### DIFF
--- a/src/main/java/org/grouplens/grapht/annotation/AnnotationProxy.java
+++ b/src/main/java/org/grouplens/grapht/annotation/AnnotationProxy.java
@@ -41,7 +41,7 @@ import java.util.Map;
 class AnnotationProxy<T extends Annotation> implements InvocationHandler, Serializable {
     private static final long serialVersionUID = 1L;
     private final ClassProxy annotationType;
-    private final Map<String, Object> attributes;
+    private final ImmutableMap<String, Object> attributes;
     private transient Class<T> cachedType;
 
     public AnnotationProxy(Class<T> type, Map<String, Object> attrs) {

--- a/src/main/java/org/grouplens/grapht/graph/DAGEdge.java
+++ b/src/main/java/org/grouplens/grapht/graph/DAGEdge.java
@@ -46,6 +46,7 @@ public class DAGEdge<V,E> implements Serializable {
     @Nonnull
     private final DAGNode<V,E> tail;
     @Nonnull
+    @SuppressWarnings("squid:S1948") // serializable warning; edge is serializable iff its label type is
     private final E label;
     private transient volatile int hashCode;
 

--- a/src/main/java/org/grouplens/grapht/graph/DAGNode.java
+++ b/src/main/java/org/grouplens/grapht/graph/DAGNode.java
@@ -54,6 +54,7 @@ public class DAGNode<V,E> implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Nonnull
+    @SuppressWarnings("squid:S1948") // serializable warning; node is serializable iff its label type is
     private final V label;
     @Nonnull
     private final ImmutableSet<DAGEdge<V,E>> outgoingEdges;

--- a/src/main/java/org/grouplens/grapht/reflect/Qualifiers.java
+++ b/src/main/java/org/grouplens/grapht/reflect/Qualifiers.java
@@ -360,6 +360,7 @@ public final class Qualifiers {
     private static class AnnotationMatcher extends AbstractMatcher implements Serializable {
         private static final long serialVersionUID = 1L;
 
+        @SuppressWarnings("squid:S1948") // serializable warning; annotations are serializable
         private final Annotation annotation;
         
         public AnnotationMatcher(Annotation annot) {

--- a/src/main/java/org/grouplens/grapht/reflect/internal/InstanceSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/InstanceSatisfaction.java
@@ -41,6 +41,7 @@ import java.util.Map;
  */
 public class InstanceSatisfaction implements Satisfaction, Serializable {
     private static final long serialVersionUID = 1L;
+    @SuppressWarnings("squid:S1948") // serializable warning; satisfaction is serializable iff instance is
     private final Object instance;
 
     /**

--- a/src/main/java/org/grouplens/grapht/reflect/internal/ProviderInstanceSatisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/ProviderInstanceSatisfaction.java
@@ -42,6 +42,7 @@ import java.util.Map;
  */
 public class ProviderInstanceSatisfaction implements Satisfaction, Serializable {
     private static final long serialVersionUID = 1L;
+    @SuppressWarnings("squid:S1948") // serializable warning; satisfaction is serializable iff provider is
     private final Provider<?> provider;
 
     /**

--- a/src/main/java/org/grouplens/grapht/util/AbstractChain.java
+++ b/src/main/java/org/grouplens/grapht/util/AbstractChain.java
@@ -32,7 +32,7 @@ import java.util.NoSuchElementException;
  * @since 0.7.0
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
-public abstract class AbstractChain<E> extends AbstractList<E> implements Serializable {
+public abstract class AbstractChain<E extends Serializable> extends AbstractList<E> implements Serializable {
     private static final long serialVersionUID = 1L;
 
     protected final AbstractChain<E> previous;

--- a/src/main/java/org/grouplens/grapht/util/AbstractChain.java
+++ b/src/main/java/org/grouplens/grapht/util/AbstractChain.java
@@ -21,6 +21,7 @@ package org.grouplens.grapht.util;
 
 import com.google.common.collect.Iterators;
 
+import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.AbstractList;
 import java.util.Iterator;
@@ -74,6 +75,7 @@ public abstract class AbstractChain<E extends Serializable> extends AbstractList
         }
     }
 
+    @Nonnull
     @Override
     public Iterator<E> iterator() {
         Iterator<E> current = Iterators.singletonIterator(tailValue);

--- a/src/main/java/org/grouplens/grapht/util/InstanceProvider.java
+++ b/src/main/java/org/grouplens/grapht/util/InstanceProvider.java
@@ -34,7 +34,7 @@ public class InstanceProvider<T> implements TypedProvider<T>, Serializable {
     private static final long serialVersionUID = -1L;
 
     private final Class<?> providedType;
-    private final T instance;
+    private final transient T instance; // transient because serialization proxy takes care of it
 
     /**
      * Construct a new instance provider.
@@ -84,6 +84,7 @@ public class InstanceProvider<T> implements TypedProvider<T>, Serializable {
     private static class SerialProxy implements Serializable {
         private static final long serialVersionUID = 1L;
         private ClassProxy type;
+        @SuppressWarnings("squid:S1948") // serializable warning; node is serializable iff its label type is
         private Object instance;
 
         public SerialProxy(Class<?> t, Object i) {

--- a/src/main/java/org/grouplens/grapht/util/InstanceProvider.java
+++ b/src/main/java/org/grouplens/grapht/util/InstanceProvider.java
@@ -41,6 +41,7 @@ public class InstanceProvider<T> implements TypedProvider<T>, Serializable {
      * @param instance The instance.
      * @deprecated Use {@link Providers#of(Object)} instead.
      */
+    @SuppressWarnings("unused")
     @Deprecated
     public InstanceProvider(T instance) {
         this(instance, instance == null ? Object.class : instance.getClass());
@@ -77,6 +78,7 @@ public class InstanceProvider<T> implements TypedProvider<T>, Serializable {
         return new SerialProxy(providedType,  instance);
     }
 
+    @SuppressWarnings("unused")
     private Object readObject() throws ObjectStreamException {
         throw new InvalidObjectException("must use serialization proxy");
     }
@@ -94,7 +96,7 @@ public class InstanceProvider<T> implements TypedProvider<T>, Serializable {
 
         @SuppressWarnings("unchecked")
         private Object readResolve() throws ObjectStreamException {
-            Class<?> cls = null;
+            Class<?> cls;
             try {
                 cls = type.resolve();
             } catch (ClassNotFoundException e) {


### PR DESCRIPTION
This cleans up several more Critical warnings from Sonar, largely around serialization.