### PR TITLE
Clean up additional warnings

### DIFF
--- a/src/main/java/org/grouplens/grapht/BindingImpl.java
+++ b/src/main/java/org/grouplens/grapht/BindingImpl.java
@@ -180,7 +180,17 @@ class BindingImpl<T> implements Binding<T> {
     public void toProvider(@Nonnull Class<? extends Provider<? extends T>> provider) {
         Satisfaction s = Satisfactions.providerType(provider);
         BindRuleBuilder brb = startRule().setSatisfaction(s);
-        generateBindings(brb, Types.getProvidedType(provider));
+        Class<?> provided;
+        try {
+            provided = Types.getProvidedType(provider);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().endsWith("is generic")) {
+                throw new InvalidBindingException(sourceType, "cannot bind to generic provider");
+            } else {
+                throw e;
+            }
+        }
+        generateBindings(brb, provided);
     }
 
     @Override

--- a/src/main/java/org/grouplens/grapht/BindingImpl.java
+++ b/src/main/java/org/grouplens/grapht/BindingImpl.java
@@ -187,7 +187,17 @@ class BindingImpl<T> implements Binding<T> {
     public void toProvider(@Nonnull Provider<? extends T> provider) {
         Satisfaction s = Satisfactions.providerInstance(provider);
         BindRuleBuilder brb = startRule().setSatisfaction(s);
-        generateBindings(brb, Types.getProvidedType(provider));
+        Class<?> provided;
+        try {
+            provided = Types.getProvidedType(provider);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().endsWith("is generic")) {
+                throw new InvalidBindingException(sourceType, "cannot bind to generic provider");
+            } else {
+                throw e;
+            }
+        }
+        generateBindings(brb, provided);
     }
 
     @Override

--- a/src/main/java/org/grouplens/grapht/reflect/internal/SimpleInjectionPoint.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/SimpleInjectionPoint.java
@@ -142,7 +142,8 @@ public final class SimpleInjectionPoint implements InjectionPoint, Serializable 
         private static final long serialVersionUID = 1L;
         private ClassProxy type;
         private boolean nullable;
-        @Nullable @SuppressWarnings("SE_BAD_FIELD")
+        @Nullable
+        @SuppressWarnings("squid:S1948") // serializable - annotations are serializable
         private Annotation qualifier;
 
         private SerialProxy(Class<?> t, boolean isNullable, @Nullable Annotation qual) {

--- a/src/test/java/org/grouplens/grapht/BindingFunctionBuilderTest.java
+++ b/src/test/java/org/grouplens/grapht/BindingFunctionBuilderTest.java
@@ -170,7 +170,6 @@ public class BindingFunctionBuilderTest {
     }
 
     @SuppressWarnings("unchecked")
-    @Ignore("currently throws IllegalArgument for generic provider")
     @Test
     public void testBindToBadProvider() throws Exception {
         // Test that we get an exception when binding to a provider of an overly generic type
@@ -178,7 +177,7 @@ public class BindingFunctionBuilderTest {
         try {
             builder.getRootContext()
                    .bind((Class) InputStream.class)
-                    .toProvider(new InstanceProvider("foo"));
+                   .toProvider(new InstanceProvider("foo"));
             fail("binding to bad provider should throw exception");
         } catch (InvalidBindingException e) {
             /* expected */

--- a/src/test/java/org/grouplens/grapht/reflect/internal/SatisfactionTest.java
+++ b/src/test/java/org/grouplens/grapht/reflect/internal/SatisfactionTest.java
@@ -153,14 +153,6 @@ public class SatisfactionTest {
         Assert.assertSame(c, s.getProvider());
     }
     
-    @Test @Ignore("Not relevant for instantiators.")
-    public void testProviderInstanceSatisfactionProvider() throws Exception {
-        ProviderC instance = new ProviderC(10);
-        Instantiator provider = new ProviderInstanceSatisfaction(instance)
-                                    .makeInstantiator(Collections.EMPTY_MAP,null);
-        Assert.assertSame(instance, provider);
-    }
-    
     @Test
     public void testClassSatisfactionEquals() throws Exception {
         // two variations of the arguments


### PR DESCRIPTION
This cleans up a stray serialization warning, and cleans out our ignored tests.