### PR TITLE
Drop defunct JSR305 in main Grapht

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,22 @@
       <version>1</version>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>15.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <version>1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>1.3.9</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/main/java/org/grouplens/grapht/AbstractContext.java
+++ b/src/main/java/org/grouplens/grapht/AbstractContext.java
@@ -19,7 +19,7 @@
  */
 package org.grouplens.grapht;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.lang.annotation.Annotation;
 
 /**

--- a/src/main/java/org/grouplens/grapht/Binding.java
+++ b/src/main/java/org/grouplens/grapht/Binding.java
@@ -22,8 +22,8 @@ package org.grouplens.grapht;
 import org.grouplens.grapht.solver.BindRule;
 import org.grouplens.grapht.reflect.Satisfaction;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
 import javax.inject.Qualifier;
 import java.lang.annotation.Annotation;
@@ -49,7 +49,7 @@ public interface Binding<T> {
      * @param qualifier The Qualifier that must match
      * @return A newly configured Binding
      */
-    Binding<T> withQualifier(@Nonnull Class<? extends Annotation> qualifier);
+    Binding<T> withQualifier(@NotNull Class<? extends Annotation> qualifier);
 
     /**
      * Configure the binding to match injection points that have been annotated with the exact
@@ -65,7 +65,7 @@ public interface Binding<T> {
      * @param annot The annotation instance to match.
      * @return A newly configured Binding
      */
-    Binding<T> withQualifier(@Nonnull Annotation annot);
+    Binding<T> withQualifier(@NotNull Annotation annot);
 
     /**
      * Configure the binding to match injection points that have any qualifier annotation (including
@@ -98,7 +98,7 @@ public interface Binding<T> {
      * @param exclude The type to exclude from automated rule generation
      * @return A newly configured Binding
      */
-    Binding<T> exclude(@Nonnull Class<?> exclude);
+    Binding<T> exclude(@NotNull Class<?> exclude);
     
     /**
      * Configure the binding so that a shared instance is always used when
@@ -143,7 +143,7 @@ public interface Binding<T> {
      * @param chained Whether further binding lookup will be done on the implementation type.
      *                {@code true} allows lookup, {@code false} creates a terminal binding.
      */
-    void to(@Nonnull Class<? extends T> impl, boolean chained);
+    void to(@NotNull Class<? extends T> impl, boolean chained);
 
     /**
      * Bind to an implementation type non-terminally.  This calls {@link #to(Class, boolean)}
@@ -151,7 +151,7 @@ public interface Binding<T> {
      *
      * @param impl The implementation type.
      */
-    void to(@Nonnull Class<? extends T> impl);
+    void to(@NotNull Class<? extends T> impl);
 
     /**
      * Complete this binding by specifying an instance to use. The instance will
@@ -171,7 +171,7 @@ public interface Binding<T> {
      * 
      * @param provider The provider type that will satisfy this binding
      */
-    void toProvider(@Nonnull Class<? extends Provider<? extends T>> provider);
+    void toProvider(@NotNull Class<? extends Provider<? extends T>> provider);
 
     /**
      * Complete this binding by specifying a Provider instance that will be used
@@ -179,7 +179,7 @@ public interface Binding<T> {
      * 
      * @param provider The provider instance
      */
-    void toProvider(@Nonnull Provider<? extends T> provider);
+    void toProvider(@NotNull Provider<? extends T> provider);
 
 
     /**
@@ -209,5 +209,5 @@ public interface Binding<T> {
      *
      * @param sat The satisfaction to bind to.
      */
-    void toSatisfaction(@Nonnull Satisfaction sat);
+    void toSatisfaction(@NotNull Satisfaction sat);
 }

--- a/src/main/java/org/grouplens/grapht/BindingImpl.java
+++ b/src/main/java/org/grouplens/grapht/BindingImpl.java
@@ -24,16 +24,19 @@ import org.grouplens.grapht.BindingFunctionBuilder.RuleSet;
 import org.grouplens.grapht.annotation.DefaultImplementation;
 import org.grouplens.grapht.annotation.DefaultProvider;
 import org.grouplens.grapht.context.ContextMatcher;
-import org.grouplens.grapht.reflect.*;
+import org.grouplens.grapht.reflect.QualifierMatcher;
+import org.grouplens.grapht.reflect.Qualifiers;
+import org.grouplens.grapht.reflect.Satisfaction;
+import org.grouplens.grapht.reflect.Satisfactions;
 import org.grouplens.grapht.solver.BindRuleBuilder;
 import org.grouplens.grapht.solver.BindingFlag;
 import org.grouplens.grapht.util.Preconditions;
 import org.grouplens.grapht.util.Types;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.inject.Provider;
 import java.lang.annotation.Annotation;
 import java.math.BigDecimal;
@@ -83,13 +86,13 @@ class BindingImpl<T> implements Binding<T> {
     }
 
     @Override
-    public Binding<T> withQualifier(@Nonnull Class<? extends Annotation> qualifier) {
+    public Binding<T> withQualifier(@NotNull Class<? extends Annotation> qualifier) {
         QualifierMatcher q = Qualifiers.match(qualifier);
         return new BindingImpl<T>(context, sourceType, excludeTypes, q, cachePolicy, fixed);
     }
     
     @Override
-    public Binding<T> withQualifier(@Nonnull Annotation annot) {
+    public Binding<T> withQualifier(@NotNull Annotation annot) {
         QualifierMatcher q = Qualifiers.match(annot);
         return new BindingImpl<T>(context, sourceType, excludeTypes, q, cachePolicy, fixed);
     }
@@ -107,7 +110,7 @@ class BindingImpl<T> implements Binding<T> {
     }
 
     @Override
-    public Binding<T> exclude(@Nonnull Class<?> exclude) {
+    public Binding<T> exclude(@NotNull Class<?> exclude) {
         Preconditions.notNull("exclude type", exclude);
         Set<Class<?>> excludes = new HashSet<Class<?>>(excludeTypes);
         excludes.add(exclude);
@@ -130,7 +133,7 @@ class BindingImpl<T> implements Binding<T> {
     }
 
     @Override
-    public void to(@Nonnull Class<? extends T> impl, boolean chained) {
+    public void to(@NotNull Class<? extends T> impl, boolean chained) {
         Preconditions.isAssignable(sourceType, impl);
         if (logger.isWarnEnabled()) {
             if (Types.shouldBeInstantiable(impl)
@@ -152,7 +155,7 @@ class BindingImpl<T> implements Binding<T> {
     }
 
     @Override
-    public void to(@Nonnull Class<? extends T> impl) {
+    public void to(@NotNull Class<? extends T> impl) {
         to(impl, true);
     }
 
@@ -177,7 +180,7 @@ class BindingImpl<T> implements Binding<T> {
     }
     
     @Override
-    public void toProvider(@Nonnull Class<? extends Provider<? extends T>> provider) {
+    public void toProvider(@NotNull Class<? extends Provider<? extends T>> provider) {
         Satisfaction s = Satisfactions.providerType(provider);
         BindRuleBuilder brb = startRule().setSatisfaction(s);
         Class<?> provided;
@@ -194,7 +197,7 @@ class BindingImpl<T> implements Binding<T> {
     }
 
     @Override
-    public void toProvider(@Nonnull Provider<? extends T> provider) {
+    public void toProvider(@NotNull Provider<? extends T> provider) {
         Satisfaction s = Satisfactions.providerInstance(provider);
         BindRuleBuilder brb = startRule().setSatisfaction(s);
         Class<?> provided;
@@ -223,7 +226,7 @@ class BindingImpl<T> implements Binding<T> {
     }
 
     @Override
-    public void toSatisfaction(@Nonnull Satisfaction sat) {
+    public void toSatisfaction(@NotNull Satisfaction sat) {
         Preconditions.notNull("satisfaction", sat);
 
         BindRuleBuilder brb = startRule().setSatisfaction(sat);

--- a/src/main/java/org/grouplens/grapht/ConstructionException.java
+++ b/src/main/java/org/grouplens/grapht/ConstructionException.java
@@ -21,7 +21,7 @@ package org.grouplens.grapht;
 
 import org.grouplens.grapht.reflect.InjectionPoint;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.lang.reflect.Member;
 
 /**

--- a/src/main/java/org/grouplens/grapht/Context.java
+++ b/src/main/java/org/grouplens/grapht/Context.java
@@ -21,7 +21,7 @@ package org.grouplens.grapht;
 
 import org.grouplens.grapht.context.ContextPattern;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.inject.Qualifier;
 import java.lang.annotation.Annotation;
 

--- a/src/main/java/org/grouplens/grapht/ContextImpl.java
+++ b/src/main/java/org/grouplens/grapht/ContextImpl.java
@@ -26,7 +26,7 @@ import org.grouplens.grapht.reflect.QualifierMatcher;
 import org.grouplens.grapht.context.Multiplicity;
 import org.grouplens.grapht.reflect.Qualifiers;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.lang.annotation.Annotation;
 
 /**

--- a/src/main/java/org/grouplens/grapht/Dependency.java
+++ b/src/main/java/org/grouplens/grapht/Dependency.java
@@ -23,7 +23,7 @@ import com.google.common.base.Predicate;
 import org.grouplens.grapht.reflect.Desire;
 import org.grouplens.grapht.solver.DesireChain;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.io.Serializable;
 import java.util.EnumSet;
 

--- a/src/main/java/org/grouplens/grapht/InjectionContainer.java
+++ b/src/main/java/org/grouplens/grapht/InjectionContainer.java
@@ -32,7 +32,7 @@ import org.grouplens.grapht.reflect.Desire;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.annotation.PreDestroy;
 import java.lang.reflect.Method;
 import java.util.*;

--- a/src/main/java/org/grouplens/grapht/Injector.java
+++ b/src/main/java/org/grouplens/grapht/Injector.java
@@ -19,8 +19,8 @@
  */
 package org.grouplens.grapht;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import javax.inject.Qualifier;
 import java.io.Closeable;
 import java.lang.annotation.Annotation;
@@ -60,7 +60,7 @@ public interface Injector extends AutoCloseable {
      * @return An instance of type T
      * @throws ConstructionException if type cannot be instantiated
      */
-    @Nonnull
+    @NotNull
     <T> T getInstance(Class<T> type) throws InjectionException;
 
     /**
@@ -72,7 +72,7 @@ public interface Injector extends AutoCloseable {
      * @return An instance of type T
      * @throws ConstructionException if type cannot be instantiated
      */
-    @Nonnull
+    @NotNull
     <T> T getInstance(Annotation qualifier, Class<T> type) throws InjectionException;
 
     /**

--- a/src/main/java/org/grouplens/grapht/context/ContextPattern.java
+++ b/src/main/java/org/grouplens/grapht/context/ContextPattern.java
@@ -27,7 +27,7 @@ import org.grouplens.grapht.reflect.Satisfaction;
 import org.grouplens.grapht.solver.InjectionContext;
 import org.grouplens.grapht.util.AbstractChain;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/org/grouplens/grapht/context/MatchElement.java
+++ b/src/main/java/org/grouplens/grapht/context/MatchElement.java
@@ -21,7 +21,7 @@ package org.grouplens.grapht.context;
 
 import com.google.common.collect.Ordering;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Comparator;
 
 /**

--- a/src/main/java/org/grouplens/grapht/context/TypeElementMatcher.java
+++ b/src/main/java/org/grouplens/grapht/context/TypeElementMatcher.java
@@ -29,7 +29,7 @@ import org.grouplens.grapht.reflect.Satisfaction;
 import org.grouplens.grapht.util.ClassProxy;
 import org.grouplens.grapht.util.Types;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.inject.Qualifier;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;

--- a/src/main/java/org/grouplens/grapht/graph/DAGEdge.java
+++ b/src/main/java/org/grouplens/grapht/graph/DAGEdge.java
@@ -23,8 +23,8 @@ import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.io.Serializable;
 
 /**
@@ -41,11 +41,11 @@ import java.io.Serializable;
 public class DAGEdge<V,E> implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    @Nonnull
+    @NotNull
     private final DAGNode<V,E> head;
-    @Nonnull
+    @NotNull
     private final DAGNode<V,E> tail;
-    @Nonnull
+    @NotNull
     @SuppressWarnings("squid:S1948") // serializable warning; edge is serializable iff its label type is
     private final E label;
     private transient volatile int hashCode;
@@ -67,7 +67,7 @@ public class DAGEdge<V,E> implements Serializable {
      * Get the edge's head (starting node).
      * @return The edge's head.
      */
-    @Nonnull
+    @NotNull
     public DAGNode<V,E> getHead() {
         return head;
     }
@@ -76,7 +76,7 @@ public class DAGEdge<V,E> implements Serializable {
      * Get the edge's tail (ending node).
      * @return The edge's tail.
      */
-    @Nonnull
+    @NotNull
     public DAGNode<V,E> getTail() {
         return tail;
     }
@@ -85,7 +85,7 @@ public class DAGEdge<V,E> implements Serializable {
      * Get the edge's label.
      * @return The edge's label.
      */
-    @Nonnull
+    @NotNull
     public E getLabel() {
         return label;
     }

--- a/src/main/java/org/grouplens/grapht/graph/DAGNode.java
+++ b/src/main/java/org/grouplens/grapht/graph/DAGNode.java
@@ -21,11 +21,11 @@ package org.grouplens.grapht.graph;
 
 import com.google.common.base.*;
 import com.google.common.collect.*;
+import net.jcip.annotations.Immutable;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
@@ -53,10 +53,10 @@ import java.util.*;
 public class DAGNode<V,E> implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    @Nonnull
+    @NotNull
     @SuppressWarnings("squid:S1948") // serializable warning; node is serializable iff its label type is
     private final V label;
-    @Nonnull
+    @NotNull
     private final ImmutableSet<DAGEdge<V,E>> outgoingEdges;
 
     private transient Supplier<SetMultimap<DAGNode<V,E>,DAGEdge<V,E>>> reverseEdgeCache;
@@ -117,7 +117,7 @@ public class DAGNode<V,E> implements Serializable {
      *              need to be constructed within the constructor in order to create the circular
      *              references back to the head nodes properly.
      */
-    DAGNode(@Nonnull V lbl, Iterable<Pair<DAGNode<V,E>,E>> edges) {
+    DAGNode(@NotNull V lbl, Iterable<Pair<DAGNode<V,E>,E>> edges) {
         label = lbl;
         ImmutableSet.Builder<DAGEdge<V,E>> bld = ImmutableSet.builder();
         for (Pair<DAGNode<V,E>,E> pair: edges) {
@@ -154,7 +154,7 @@ public class DAGNode<V,E> implements Serializable {
      * Get the label for this node.
      * @return The node's label.
      */
-    @Nonnull
+    @NotNull
     public V getLabel() {
         return label;
     }
@@ -163,7 +163,7 @@ public class DAGNode<V,E> implements Serializable {
      * Get the outgoing edges of this node.
      * @return The outgoing edges of the node.
      */
-    @Nonnull
+    @NotNull
     public Set<DAGEdge<V,E>> getOutgoingEdges() {
         return outgoingEdges;
     }
@@ -224,12 +224,12 @@ public class DAGNode<V,E> implements Serializable {
      *
      * @return The reverse edge map.
      */
-    @Nonnull
+    @NotNull
     private SetMultimap<DAGNode<V,E>,DAGEdge<V,E>> getIncomingEdgeMap() {
         return reverseEdgeCache.get();
     }
 
-    @Nonnull
+    @NotNull
     public Set<DAGNode<V,E>> getReachableNodes() {
         return reachableNodeCache.get();
     }
@@ -243,7 +243,7 @@ public class DAGNode<V,E> implements Serializable {
      * the returned list.
      * @return The sorted list of reachable nodes.
      */
-    @Nonnull
+    @NotNull
     public List<DAGNode<V,E>> getSortedNodes() {
         return topologicalSortCache.get();
     }
@@ -270,7 +270,7 @@ public class DAGNode<V,E> implements Serializable {
      * Get the incoming edges to a node reachable from this node.
      * @return The set of incoming edges, or an empty set if the node is not reachable.
      */
-    @Nonnull
+    @NotNull
     public Set<DAGEdge<V,E>> getIncomingEdges(DAGNode<V,E> node) {
         return getIncomingEdgeMap().get(node);
     }
@@ -317,7 +317,7 @@ public class DAGNode<V,E> implements Serializable {
      * @return The first node matching {@code pred} in a breadth-first search, or {@code null} if no
      *         such node is found.
      */
-    public DAGNode<V, E> findNodeBFS(@Nonnull Predicate<? super DAGNode<V, E>> pred) {
+    public DAGNode<V, E> findNodeBFS(@NotNull Predicate<? super DAGNode<V, E>> pred) {
         if (pred.apply(this)) {
             return this;
         }
@@ -353,7 +353,7 @@ public class DAGNode<V,E> implements Serializable {
      * @return The first node matching {@code pred} in a breadth-first search, or {@code null} if no
      *         such node is found.
      */
-    public DAGEdge<V, E> findEdgeBFS(@Nonnull Predicate<? super DAGEdge<V, E>> pred) {
+    public DAGEdge<V, E> findEdgeBFS(@NotNull Predicate<? super DAGEdge<V, E>> pred) {
         Queue<DAGNode<V, E>> work = Lists.newLinkedList();
         Set<DAGNode<V, E>> seen = Sets.newHashSet();
         work.add(this);

--- a/src/main/java/org/grouplens/grapht/graph/DAGNodeBuilder.java
+++ b/src/main/java/org/grouplens/grapht/graph/DAGNodeBuilder.java
@@ -23,7 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Set;
 
 /**
@@ -51,8 +51,8 @@ public class DAGNodeBuilder<V,E> {
      * @param lbl The node's label.
      * @return The builder (for chaining).
      */
-    @Nonnull
-    public DAGNodeBuilder<V,E> setLabel(@Nonnull V lbl) {
+    @NotNull
+    public DAGNodeBuilder<V,E> setLabel(@NotNull V lbl) {
         Preconditions.checkNotNull(lbl, "node label");
         label = lbl;
         return this;
@@ -72,9 +72,9 @@ public class DAGNodeBuilder<V,E> {
      * @param label The edge label.
      * @return The builder (for chaining).
      */
-    @Nonnull
-    public DAGNodeBuilder<V,E> addEdge(@Nonnull DAGNode<V,E> target,
-                                       @Nonnull E label) {
+    @NotNull
+    public DAGNodeBuilder<V,E> addEdge(@NotNull DAGNode<V,E> target,
+                                       @NotNull E label) {
         Preconditions.checkNotNull(target, "edge target");
         Preconditions.checkNotNull(label, "edge label");
         return addEdge(Pair.of(target, label));
@@ -85,7 +85,7 @@ public class DAGNodeBuilder<V,E> {
      * @param edge The target node and label for the edge.
      * @return The builder (for chaining).
      */
-    @Nonnull
+    @NotNull
     public DAGNodeBuilder<V,E> addEdge(Pair<DAGNode<V,E>,E> edge) {
         Preconditions.checkNotNull(edge, "edge");
         Preconditions.checkNotNull(edge.getLeft(), "edge target");
@@ -100,12 +100,12 @@ public class DAGNodeBuilder<V,E> {
      *
      * @return The set of edges.
      */
-    @Nonnull
+    @NotNull
     public Set<Pair<DAGNode<V,E>,E>> getEdges() {
         return edges;
     }
 
-    @Nonnull
+    @NotNull
     public DAGNode<V,E> build() {
         Preconditions.checkState(label != null, "no node label set");
         return new DAGNode<V,E>(label, edges);

--- a/src/main/java/org/grouplens/grapht/reflect/Desires.java
+++ b/src/main/java/org/grouplens/grapht/reflect/Desires.java
@@ -22,7 +22,7 @@ package org.grouplens.grapht.reflect;
 import org.grouplens.grapht.reflect.internal.ReflectionDesire;
 import org.grouplens.grapht.reflect.internal.SimpleInjectionPoint;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.lang.annotation.Annotation;
 
 /**

--- a/src/main/java/org/grouplens/grapht/reflect/InjectionPoint.java
+++ b/src/main/java/org/grouplens/grapht/reflect/InjectionPoint.java
@@ -19,8 +19,9 @@
  */
 package org.grouplens.grapht.reflect;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
@@ -73,7 +74,7 @@ public interface InjectionPoint extends Serializable {
      * @return Immutable collection of attribute annotations (does not include
      *         the qualifier)
      */
-    @Nonnull
+    @NotNull
     Collection<Annotation> getAttributes();
 
     /**

--- a/src/main/java/org/grouplens/grapht/reflect/QualifierMatcher.java
+++ b/src/main/java/org/grouplens/grapht/reflect/QualifierMatcher.java
@@ -20,8 +20,8 @@
 package org.grouplens.grapht.reflect;
 
 import com.google.common.base.Predicate;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import javax.inject.Qualifier;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;

--- a/src/main/java/org/grouplens/grapht/reflect/Qualifiers.java
+++ b/src/main/java/org/grouplens/grapht/reflect/Qualifiers.java
@@ -28,7 +28,7 @@ import org.grouplens.grapht.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import javax.inject.Qualifier;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
@@ -68,8 +68,8 @@ public final class Qualifiers {
      * @throws java.lang.IllegalArgumentException if there is a problem with the type, such as a
      *                                            circular alias reference.
      */
-    @Nonnull
-    public static Class<? extends Annotation> resolveAliases(@Nonnull Class<? extends Annotation> type) {
+    @NotNull
+    public static Class<? extends Annotation> resolveAliases(@NotNull Class<? extends Annotation> type) {
         Preconditions.notNull("qualifier type", type);
         Set<Class<? extends Annotation>> seen = Sets.newHashSet();
         seen.add(type);

--- a/src/main/java/org/grouplens/grapht/reflect/Satisfaction.java
+++ b/src/main/java/org/grouplens/grapht/reflect/Satisfaction.java
@@ -19,10 +19,13 @@
  */
 package org.grouplens.grapht.reflect;
 
-import org.grouplens.grapht.*;
+import org.grouplens.grapht.CachePolicy;
+import org.grouplens.grapht.Injector;
+import org.grouplens.grapht.Instantiator;
+import org.grouplens.grapht.LifecycleManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import java.io.Serializable;
 import java.lang.reflect.Type;
@@ -115,6 +118,6 @@ public interface Satisfaction extends Serializable {
      *         satisfaction, instantiated using the specified dependency
      *         mapping.
      */
-    Instantiator makeInstantiator(@Nonnull Map<Desire,Instantiator> dependencies,
+    Instantiator makeInstantiator(@NotNull Map<Desire,Instantiator> dependencies,
                                   @Nullable LifecycleManager lm);
 }

--- a/src/main/java/org/grouplens/grapht/reflect/Satisfactions.java
+++ b/src/main/java/org/grouplens/grapht/reflect/Satisfactions.java
@@ -21,7 +21,7 @@ package org.grouplens.grapht.reflect;
 
 import org.grouplens.grapht.reflect.internal.*;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import javax.inject.Provider;
 
 /**
@@ -33,23 +33,23 @@ import javax.inject.Provider;
 public final class Satisfactions {
     private Satisfactions() {}
 
-    public static Satisfaction type(@Nonnull Class<?> type) {
+    public static Satisfaction type(@NotNull Class<?> type) {
         return new ClassSatisfaction(type);
     }
 
-    public static Satisfaction nullOfType(@Nonnull Class<?> type) {
+    public static Satisfaction nullOfType(@NotNull Class<?> type) {
         return new NullSatisfaction(type);
     }
 
-    public static Satisfaction instance(@Nonnull Object o) {
+    public static Satisfaction instance(@NotNull Object o) {
         return new InstanceSatisfaction(o);
     }
 
-    public static Satisfaction providerType(@Nonnull Class<? extends Provider<?>> providerType) {
+    public static Satisfaction providerType(@NotNull Class<? extends Provider<?>> providerType) {
         return new ProviderClassSatisfaction(providerType);
     }
 
-    public static Satisfaction providerInstance(@Nonnull Provider<?> provider) {
+    public static Satisfaction providerInstance(@NotNull Provider<?> provider) {
         return new ProviderInstanceSatisfaction(provider);
     }
 }

--- a/src/main/java/org/grouplens/grapht/reflect/internal/FieldInjectionPoint.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/FieldInjectionPoint.java
@@ -24,8 +24,8 @@ import org.grouplens.grapht.util.FieldProxy;
 import org.grouplens.grapht.util.Preconditions;
 import org.grouplens.grapht.util.Types;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
@@ -51,7 +51,7 @@ public final class FieldInjectionPoint implements InjectionPoint, Serializable {
      * @param field The field to inject
      * @throws NullPointerException if field is null
      */
-    public FieldInjectionPoint(@Nonnull Field field) {
+    public FieldInjectionPoint(@NotNull Field field) {
         Preconditions.notNull("field", field);
         this.field = field;
         annotations = new AnnotationHelper(field.getAnnotations());
@@ -79,13 +79,13 @@ public final class FieldInjectionPoint implements InjectionPoint, Serializable {
         return annotations.getAttribute(atype);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Collection<Annotation> getAttributes() {
         return annotations.getAttributes();
     }
 
-    @Override @Nonnull
+    @Override @NotNull
     public Field getMember() {
         return field;
     }

--- a/src/main/java/org/grouplens/grapht/reflect/internal/OptionalInjectionPoint.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/OptionalInjectionPoint.java
@@ -24,8 +24,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.grouplens.grapht.reflect.InjectionPoint;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
 import java.lang.reflect.Type;
@@ -73,7 +73,7 @@ public class OptionalInjectionPoint implements InjectionPoint {
         return delegate.getAttribute(atype);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Collection<Annotation> getAttributes() {
         return delegate.getAttributes();

--- a/src/main/java/org/grouplens/grapht/reflect/internal/ParameterInjectionPoint.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/ParameterInjectionPoint.java
@@ -24,8 +24,8 @@ import org.grouplens.grapht.util.MemberProxy;
 import org.grouplens.grapht.util.Preconditions;
 import org.grouplens.grapht.util.Types;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
@@ -51,7 +51,7 @@ public class ParameterInjectionPoint implements InjectionPoint, Serializable {
      * @param mem The constructor or method.
      * @param param The parameter index.
      */
-    public ParameterInjectionPoint(@Nonnull Executable mem, int param) {
+    public ParameterInjectionPoint(@NotNull Executable mem, int param) {
         Preconditions.notNull("ctor method", mem);
         Preconditions.inRange(param, 0, mem.getParameterTypes().length);
 
@@ -63,7 +63,7 @@ public class ParameterInjectionPoint implements InjectionPoint, Serializable {
     /**
      * @return The method or constructor wrapped by this injection point
      */
-    @Override @Nonnull
+    @Override @NotNull
     public Executable getMember() {
         return member;
     }
@@ -105,7 +105,7 @@ public class ParameterInjectionPoint implements InjectionPoint, Serializable {
         return annotations.getAttribute(atype);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Collection<Annotation> getAttributes() {
         return annotations.getAttributes();

--- a/src/main/java/org/grouplens/grapht/reflect/internal/SimpleInjectionPoint.java
+++ b/src/main/java/org/grouplens/grapht/reflect/internal/SimpleInjectionPoint.java
@@ -26,8 +26,8 @@ import org.grouplens.grapht.reflect.InjectionPoint;
 import org.grouplens.grapht.util.ClassProxy;
 import org.grouplens.grapht.util.Preconditions;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
@@ -92,7 +92,7 @@ public final class SimpleInjectionPoint implements InjectionPoint, Serializable 
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Collection<Annotation> getAttributes() {
         return Collections.emptyList();

--- a/src/main/java/org/grouplens/grapht/solver/BindRuleImpl.java
+++ b/src/main/java/org/grouplens/grapht/solver/BindRuleImpl.java
@@ -29,8 +29,8 @@ import org.grouplens.grapht.util.ClassProxy;
 import org.grouplens.grapht.util.Preconditions;
 import org.grouplens.grapht.util.Types;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
@@ -68,10 +68,10 @@ final class BindRuleImpl implements BindRule, Serializable {
      * @param flags The flags to apply to this bind rule and its results.
      * @throws NullPointerException if arguments are null
      */
-    public BindRuleImpl(@Nonnull Class<?> depType,
-                        @Nonnull Satisfaction satisfaction,
-                        @Nonnull CachePolicy policy,
-                        @Nonnull QualifierMatcher qualifier,
+    public BindRuleImpl(@NotNull Class<?> depType,
+                        @NotNull Satisfaction satisfaction,
+                        @NotNull CachePolicy policy,
+                        @NotNull QualifierMatcher qualifier,
                         EnumSet<BindingFlag> flags) {
         Preconditions.notNull("dependency type", depType);
         Preconditions.notNull("satisfaction", satisfaction);
@@ -101,10 +101,10 @@ final class BindRuleImpl implements BindRule, Serializable {
      * @param flags The flags to apply to this bind rule and its results.
      * @throws NullPointerException if arguments are null
      */
-    public BindRuleImpl(@Nonnull Class<?> depType,
-                        @Nonnull Class<?> implType,
-                        @Nonnull CachePolicy policy,
-                        @Nonnull QualifierMatcher qualifier,
+    public BindRuleImpl(@NotNull Class<?> depType,
+                        @NotNull Class<?> implType,
+                        @NotNull CachePolicy policy,
+                        @NotNull QualifierMatcher qualifier,
                         EnumSet<BindingFlag> flags) {
         Preconditions.notNull("dependency type", depType);
         Preconditions.notNull("implementation type", implType);

--- a/src/main/java/org/grouplens/grapht/solver/BindingFunction.java
+++ b/src/main/java/org/grouplens/grapht/solver/BindingFunction.java
@@ -21,7 +21,7 @@ package org.grouplens.grapht.solver;
 
 import org.grouplens.grapht.ResolutionException;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Locate bindings for an injection point.

--- a/src/main/java/org/grouplens/grapht/solver/DefaultInjector.java
+++ b/src/main/java/org/grouplens/grapht/solver/DefaultInjector.java
@@ -20,6 +20,7 @@
 package org.grouplens.grapht.solver;
 
 import com.google.common.base.Predicate;
+import net.jcip.annotations.ThreadSafe;
 import org.grouplens.grapht.*;
 import org.grouplens.grapht.graph.DAGEdge;
 import org.grouplens.grapht.graph.DAGNode;
@@ -28,9 +29,8 @@ import org.grouplens.grapht.reflect.Desires;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.ThreadSafe;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.lang.annotation.Annotation;
 
 /**
@@ -122,13 +122,13 @@ public class DefaultInjector implements Injector {
         return solver;
     }
     
-    @Nonnull
+    @NotNull
     @Override
     public <T> T getInstance(Class<T> type) throws InjectionException {
         return getInstance(null, type);
     }
     
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getInstance(Annotation qualifier, Class<T> type) throws InjectionException {

--- a/src/main/java/org/grouplens/grapht/solver/DependencySolverBuilder.java
+++ b/src/main/java/org/grouplens/grapht/solver/DependencySolverBuilder.java
@@ -22,7 +22,7 @@ package org.grouplens.grapht.solver;
 import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.util.Preconditions;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -64,7 +64,7 @@ public class DependencySolverBuilder {
      * @param func The binding function.
      * @return The builder (for chaining).
      */
-    public DependencySolverBuilder addBindingFunction(@Nonnull BindingFunction func) {
+    public DependencySolverBuilder addBindingFunction(@NotNull BindingFunction func) {
         return addBindingFunction(func, true);
     }
 
@@ -80,7 +80,7 @@ public class DependencySolverBuilder {
      *                          {@code false} here to keep default bindings from triggering rewrites.
      * @return The builder (for chaining).
      */
-    public DependencySolverBuilder addBindingFunction(@Nonnull BindingFunction func,
+    public DependencySolverBuilder addBindingFunction(@NotNull BindingFunction func,
                                                       boolean canTriggerRewrite) {
         Preconditions.notNull("binding function", func);
         bindingFunctions.add(func);
@@ -95,7 +95,7 @@ public class DependencySolverBuilder {
      * @param funcs The binding functions.
      * @return The builder (for chaining).
      */
-    public DependencySolverBuilder addBindingFunctions(@Nonnull BindingFunction... funcs) {
+    public DependencySolverBuilder addBindingFunctions(@NotNull BindingFunction... funcs) {
         return addBindingFunctions(Arrays.asList(funcs));
     }
 
@@ -104,7 +104,7 @@ public class DependencySolverBuilder {
      * @param funcs The binding functions.
      * @return The builder (for chaining).
      */
-    public DependencySolverBuilder addBindingFunctions(@Nonnull Iterable<BindingFunction> funcs) {
+    public DependencySolverBuilder addBindingFunctions(@NotNull Iterable<BindingFunction> funcs) {
         for (BindingFunction fn: funcs) {
             addBindingFunction(fn);
         }

--- a/src/main/java/org/grouplens/grapht/solver/DesireChain.java
+++ b/src/main/java/org/grouplens/grapht/solver/DesireChain.java
@@ -23,8 +23,8 @@ import com.google.common.base.Predicate;
 import org.grouplens.grapht.reflect.Desire;
 import org.grouplens.grapht.util.AbstractChain;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -42,7 +42,7 @@ import java.util.UUID;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public class DesireChain extends AbstractChain<Desire> {
-    @Nonnull
+    @NotNull
     private final Desire initialDesire;
     private final UUID key;
 
@@ -55,7 +55,7 @@ public class DesireChain extends AbstractChain<Desire> {
      * @param prev The previous chain.
      * @param d The desire.
      */
-    private DesireChain(DesireChain prev, @Nonnull Desire d) {
+    private DesireChain(DesireChain prev, @NotNull Desire d) {
         super(prev, d);
         key = prev == null ? UUID.randomUUID() : prev.key;
         initialDesire = prev == null ? d : prev.getInitialDesire();
@@ -70,12 +70,12 @@ public class DesireChain extends AbstractChain<Desire> {
         };
     }
 
-    @Nonnull
+    @NotNull
     public Desire getCurrentDesire() {
         return tailValue;
     }
 
-    @Nonnull
+    @NotNull
     public Desire getInitialDesire() {
         return initialDesire;
     }
@@ -84,7 +84,7 @@ public class DesireChain extends AbstractChain<Desire> {
      * Return the list of desires up to, but not including, the current desire.
      * @return The previous desire chain.
      */
-    @Nonnull
+    @NotNull
     public List<Desire> getPreviousDesires() {
         if (previous == null) {
             return Collections.emptyList();
@@ -97,7 +97,7 @@ public class DesireChain extends AbstractChain<Desire> {
      * Return the desire chain up to, but not including, the current desire.
      * @return The previous desire chain.
      */
-    @Nonnull
+    @NotNull
     public DesireChain getPreviousDesireChain() {
         if (previous == null) {
             throw new IllegalArgumentException("cannot get previous chain from singleton");
@@ -124,8 +124,8 @@ public class DesireChain extends AbstractChain<Desire> {
      * @param d The new current desire.
      * @return The new desire chain.
      */
-    @Nonnull
-    public DesireChain extend(@Nonnull Desire d) {
+    @NotNull
+    public DesireChain extend(@NotNull Desire d) {
         return new DesireChain(this, d);
     }
 }

--- a/src/main/java/org/grouplens/grapht/solver/InjectionContext.java
+++ b/src/main/java/org/grouplens/grapht/solver/InjectionContext.java
@@ -25,7 +25,7 @@ import org.grouplens.grapht.reflect.Satisfaction;
 import org.grouplens.grapht.reflect.internal.SimpleInjectionPoint;
 import org.grouplens.grapht.util.AbstractChain;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * <p>

--- a/src/main/java/org/grouplens/grapht/util/AbstractChain.java
+++ b/src/main/java/org/grouplens/grapht/util/AbstractChain.java
@@ -20,8 +20,8 @@
 package org.grouplens.grapht.util;
 
 import com.google.common.collect.Iterators;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.AbstractList;
 import java.util.Iterator;
@@ -75,7 +75,7 @@ public abstract class AbstractChain<E extends Serializable> extends AbstractList
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Iterator<E> iterator() {
         Iterator<E> current = Iterators.singletonIterator(tailValue);

--- a/src/main/java/org/grouplens/grapht/util/ClassProxy.java
+++ b/src/main/java/org/grouplens/grapht/util/ClassProxy.java
@@ -19,13 +19,13 @@
  */
 package org.grouplens.grapht.util;
 
+import net.jcip.annotations.Immutable;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.io.ObjectInputStream;

--- a/src/main/java/org/grouplens/grapht/util/ConstructorProxy.java
+++ b/src/main/java/org/grouplens/grapht/util/ConstructorProxy.java
@@ -21,7 +21,7 @@ package org.grouplens.grapht.util;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;

--- a/src/main/java/org/grouplens/grapht/util/FieldProxy.java
+++ b/src/main/java/org/grouplens/grapht/util/FieldProxy.java
@@ -21,7 +21,7 @@ package org.grouplens.grapht.util;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 

--- a/src/main/java/org/grouplens/grapht/util/InstanceProvider.java
+++ b/src/main/java/org/grouplens/grapht/util/InstanceProvider.java
@@ -19,7 +19,7 @@
  */
 package org.grouplens.grapht.util;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;

--- a/src/main/java/org/grouplens/grapht/util/MemoizingProvider.java
+++ b/src/main/java/org/grouplens/grapht/util/MemoizingProvider.java
@@ -19,8 +19,9 @@
  */
 package org.grouplens.grapht.util;
 
-import javax.annotation.Nonnull;
-import javax.annotation.concurrent.ThreadSafe;
+import net.jcip.annotations.ThreadSafe;
+import org.jetbrains.annotations.NotNull;
+
 import javax.inject.Provider;
 
 /**
@@ -40,7 +41,7 @@ public class MemoizingProvider<T> implements TypedProvider<T> {
     private volatile T cached;
     private volatile boolean invoked;
 
-    public MemoizingProvider(@Nonnull Provider<T> provider) {
+    public MemoizingProvider(@NotNull Provider<T> provider) {
         Preconditions.notNull("provider", provider);
         wrapped = provider;
         cached = null;

--- a/src/main/java/org/grouplens/grapht/util/MethodProxy.java
+++ b/src/main/java/org/grouplens/grapht/util/MethodProxy.java
@@ -21,7 +21,7 @@ package org.grouplens.grapht.util;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.Arrays;

--- a/src/main/java/org/grouplens/grapht/util/Providers.java
+++ b/src/main/java/org/grouplens/grapht/util/Providers.java
@@ -21,8 +21,8 @@ package org.grouplens.grapht.util;
 
 import com.google.common.base.Supplier;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
 
 /**
@@ -34,7 +34,7 @@ import javax.inject.Provider;
 public final class Providers {
     private Providers() {}
 
-    public static <T> Provider<T> of(@Nonnull T object) {
+    public static <T> Provider<T> of(@NotNull T object) {
         return new InstanceProvider<T>(object, object.getClass());
     }
 
@@ -42,7 +42,7 @@ public final class Providers {
         return new InstanceProvider<T>(object, type);
     }
 
-    public static <T> Provider<T> memoize(@Nonnull Provider<T> inner) {
+    public static <T> Provider<T> memoize(@NotNull Provider<T> inner) {
         return new MemoizingProvider<T>(inner);
     }
 

--- a/src/main/java/org/grouplens/grapht/util/Types.java
+++ b/src/main/java/org/grouplens/grapht/util/Types.java
@@ -21,7 +21,7 @@ package org.grouplens.grapht.util;
 
 import org.apache.commons.lang3.reflect.TypeUtils;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import java.lang.annotation.Annotation;
@@ -197,7 +197,7 @@ public final class Types {
      * @return The type distance
      * @throws IllegalArgumentException if {@code child} is not a subtype of {@code parent}.
      */
-    public static int getTypeDistance(@Nonnull Class<?> child, @Nonnull Class<?> parent) {
+    public static int getTypeDistance(@NotNull Class<?> child, @NotNull Class<?> parent) {
         Preconditions.notNull("child class", child);
         Preconditions.notNull("parent class", parent);
 


### PR DESCRIPTION
- Use JetBrains annotations for nullability
- Use JCIP annotations for thread safety

This also changes things so that none of these annotation jars are exposed as transitive dependencies.