### PR TITLE
Use Java 8 functional interfaces

### DIFF
--- a/src/main/java/org/grouplens/grapht/Dependency.java
+++ b/src/main/java/org/grouplens/grapht/Dependency.java
@@ -80,17 +80,12 @@ public class Dependency implements Serializable {
     }
 
     /**
-     * Create a predicate matching dependencies with the specified initial desire.
+     * Query whether this dependency has a particular initial desire.
      * @param d The desire.
-     * @return A predicate that accepts dependencies whose initial desire is {@code d}.
+     * @return {@code true} if the dependency's initial desire is {@code d}.
      */
-    public static Predicate<Dependency> hasInitialDesire(final Desire d) {
-        return new Predicate<Dependency>() {
-            @Override
-            public boolean apply(@Nullable Dependency input) {
-                return input != null && input.getInitialDesire().equals(d);
-            }
-        };
+    public boolean hasInitialDesire(Desire d) {
+        return getInitialDesire().equals(d);
     }
 
     @Override

--- a/src/main/java/org/grouplens/grapht/graph/DAGEdge.java
+++ b/src/main/java/org/grouplens/grapht/graph/DAGEdge.java
@@ -23,8 +23,6 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.Serializable;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
  * Edges in DAGs.  These arise from building nodes with a {@link DAGNodeBuilder}.
@@ -121,52 +119,5 @@ public class DAGEdge<V,E> implements Serializable {
           .append(" to ")
           .append(tail);
         return sb.toString();
-    }
-
-    public static <E> Predicate<DAGEdge<?,E>> labelMatches(final Predicate<? super E> pred) {
-        return input -> {
-            E label = input == null ? null : input.getLabel();
-            return pred.test(label);
-        };
-    }
-
-    public static <V,E> Predicate<DAGEdge<V,E>> tailMatches(final Predicate<? super DAGNode<V,E>> pred) {
-        return input -> {
-            DAGNode<V,E> tail = input == null ? null : input.getTail();
-            return pred.test(tail);
-        };
-    }
-
-    /**
-     * Transform an edge.  This function does not further transform the nodes, so if the edge is
-     * known as the outgoing edge of a node, that won't be fixed.  Mostly useful for bulk operations
-     * on a bunch of edges, if you have them lying around.
-     *
-     * @param func The node transformation function.  If this function returns null, that is treated
-     *             as equivalent to the identity function.
-     * @param <V> The type of vertices.
-     * @param <E> The type of edges.
-     * @return A function over edges.
-     */
-    public static <V,E> Function<DAGEdge<V,E>,DAGEdge<V,E>> transformNodes(final Function<? super DAGNode<V,E>,? extends DAGNode<V,E>> func) {
-        return input -> {
-            if (input == null) {
-                return null;
-            }
-            DAGNode<V,E> nt, nh;
-            nt = func.apply(input.getTail());
-            nh = func.apply(input.getHead());
-            if (nt == null) {
-                nt = input.getTail();
-            }
-            if (nh == null) {
-                nh = input.getHead();
-            }
-            if (!nt.equals(input.getTail()) || !nh.equals(input.getHead())) {
-                return create(nh, nt, input.getLabel());
-            } else {
-                return input;
-            }
-        };
     }
 }

--- a/src/main/java/org/grouplens/grapht/graph/DAGNode.java
+++ b/src/main/java/org/grouplens/grapht/graph/DAGNode.java
@@ -212,9 +212,8 @@ public class DAGNode<V,E> implements Serializable {
      */
     @Nullable
     public DAGEdge<V, E> getOutgoingEdgeWithLabel(Predicate<? super E> predicate) {
-        Predicate<DAGEdge<?, E>> edgePred = DAGEdge.labelMatches(predicate);
         return outgoingEdges.stream()
-                            .filter(edgePred)
+                            .filter(e -> predicate.test(e.getLabel()))
                             .findFirst()
                             .orElse(null);
     }
@@ -451,13 +450,6 @@ public class DAGNode<V,E> implements Serializable {
           .append(outgoingEdges.size())
           .append(" edges");
         return sb.toString();
-    }
-
-    public static <V> Predicate<DAGNode<V,?>> labelMatches(final Predicate<? super V> pred) {
-        return input -> {
-            V lbl = input == null ? null : input.getLabel();
-            return pred.test(lbl);
-        };
     }
 
     /**

--- a/src/main/java/org/grouplens/grapht/graph/MergePool.java
+++ b/src/main/java/org/grouplens/grapht/graph/MergePool.java
@@ -20,7 +20,6 @@
 package org.grouplens.grapht.graph;
 
 import com.google.common.base.Functions;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.tuple.Pair;
@@ -30,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Merges graphs to remove redundant nodes.  This takes graphs and merges them, pruning redundant
@@ -91,10 +91,11 @@ public class MergePool<V,E> {
             // Resolve the merged neighbors of this node.  They have already been
             // merged, since we are going in topological order.
             Set<DAGNode<V, E>> neighbors =
-                    FluentIterable.from(toMerge.getOutgoingEdges())
-                                  .transform(DAGEdge.<V,E>extractTail())
-                                  .transform(Functions.forMap(mergedMap))
-                                  .toSet();
+                    toMerge.getOutgoingEdges()
+                           .stream()
+                           .map(DAGEdge::getTail)
+                           .map(Functions.forMap(mergedMap))
+                           .collect(Collectors.toSet());
 
             // See if we have already created an equivalent to this node
             DAGNode<V, E> newNode = nodeTable.get(Pair.of(sat, neighbors));

--- a/src/main/java/org/grouplens/grapht/solver/DefaultInjector.java
+++ b/src/main/java/org/grouplens/grapht/solver/DefaultInjector.java
@@ -19,18 +19,17 @@
  */
 package org.grouplens.grapht.solver;
 
-import com.google.common.base.Predicate;
 import net.jcip.annotations.ThreadSafe;
 import org.grouplens.grapht.*;
 import org.grouplens.grapht.graph.DAGEdge;
 import org.grouplens.grapht.graph.DAGNode;
 import org.grouplens.grapht.reflect.Desire;
 import org.grouplens.grapht.reflect.Desires;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import java.lang.annotation.Annotation;
 
 /**
@@ -149,11 +148,10 @@ public class DefaultInjector implements Injector {
         // within this exclusive lock so we know everything is thread safe
         // albeit in a non-optimal way.
         synchronized(this) {
-            Predicate<Dependency> pred = Dependency.hasInitialDesire(desire);
-
             // check if the desire is already in the graph
             DAGEdge<Component, Dependency> resolved =
-                    solver.getGraph().getOutgoingEdgeWithLabel(pred);
+                    solver.getGraph()
+                          .getOutgoingEdgeWithLabel(d -> d.hasInitialDesire(desire));
 
             // The edge is only non-null if instantiate() has been called before,
             // it may be present in the graph at a deeper node. If that's the case
@@ -161,7 +159,8 @@ public class DefaultInjector implements Injector {
             if (resolved == null) {
                 logger.info("Must resolve desire: {}", desire);
                 solver.resolve(desire);
-                resolved = solver.getGraph().getOutgoingEdgeWithLabel(pred);
+                resolved = solver.getGraph()
+                                 .getOutgoingEdgeWithLabel(d -> d.hasInitialDesire(desire));
             }
 
             // Check if the provider for the resolved node is in our cache

--- a/src/main/java/org/grouplens/grapht/solver/DependencySolver.java
+++ b/src/main/java/org/grouplens/grapht/solver/DependencySolver.java
@@ -20,8 +20,10 @@
 package org.grouplens.grapht.solver;
 
 import com.google.common.base.Functions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.*;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.SetMultimap;
 import org.apache.commons.lang3.tuple.Pair;
 import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.Component;
@@ -158,13 +160,13 @@ public class DependencySolver {
      * @see #getBackEdges()
      */
     public synchronized DAGNode<Component, Dependency> getBackEdge(DAGNode<Component, Dependency> parent,
-                                                                            Desire desire) {
-        Predicate<DAGEdge<?, Dependency>> pred = DAGEdge.labelMatches(Dependency.hasInitialDesire(desire));
-        return FluentIterable.from(backEdges.get(parent))
-                             .filter(pred)
-                             .first()
-                             .transform(DAGEdge.<Component, Dependency>extractTail())
-                             .orNull();
+                                                                   Desire desire) {
+        return backEdges.get(parent)
+                .stream()
+                .filter(e -> e.getLabel().hasInitialDesire(desire))
+                .findFirst()
+                .map(DAGEdge::getTail)
+                .orElse(null);
     }
 
     /**

--- a/src/test/java/org/grouplens/grapht/graph/TestDAGNode.java
+++ b/src/test/java/org/grouplens/grapht/graph/TestDAGNode.java
@@ -21,7 +21,6 @@ package org.grouplens.grapht.graph;
 
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
-import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Maps;
 import org.junit.Test;
@@ -312,8 +311,7 @@ public class TestDAGNode {
                                             .addEdge(foo, "-> foo")
                                             .addEdge(baz, "-> baz")
                                             .build();
-        Predicate<DAGEdge<?, String>> pred = DAGEdge.labelMatches(Predicates.equalTo("-> baz"));
-        DAGEdge<String,String> edge = bar.findEdgeBFS(pred);
+        DAGEdge<String,String> edge = bar.findEdgeBFS(e -> e.getLabel().equals("-> baz"));
         // we should find the correct edge
         assertThat(edge, isIn(bar.getOutgoingEdges()));
         assertThat(edge.getTail(), equalTo(baz));
@@ -330,7 +328,7 @@ public class TestDAGNode {
                                             .addEdge(bar, "wombat")
                                             .addEdge(foo, "goodbye")
                                             .build();
-        DAGEdge<String,String> edge = bam.findEdgeBFS(DAGEdge.tailMatches(Predicates.equalTo(foo)));
+        DAGEdge<String,String> edge = bam.findEdgeBFS(e -> e.getTail().equals(foo));
         // we should find the first edge
         assertThat(edge.getLabel(),
                    equalTo("goodbye"));

--- a/src/test/java/org/grouplens/grapht/graph/TestDAGNode.java
+++ b/src/test/java/org/grouplens/grapht/graph/TestDAGNode.java
@@ -252,7 +252,7 @@ public class TestDAGNode {
                                             .addEdge(foo, "foo")
                                             .build();
         DAGNode<String,String> needle =
-                bar.findNodeBFS(DAGNode.labelMatches(Predicates.equalTo("foo")));
+                bar.findNodeBFS(e -> e.getLabel().equals("foo"));
         assertThat(needle, sameInstance(foo));
     }
 
@@ -277,7 +277,7 @@ public class TestDAGNode {
                                             .addEdge(bar, "wombat")
                                             .addEdge(foo2, "goodbye")
                                             .build();
-        DAGNode<String,String> needle = bam.findNodeBFS(DAGNode.labelMatches(Predicates.equalTo("foo")));
+        DAGNode<String,String> needle = bam.findNodeBFS(e -> e.getLabel().equals("foo"));
         assertThat(needle, sameInstance(foo2));
     }
 

--- a/src/test/java/org/grouplens/grapht/reflect/internal/ReflectionInjectionTest.java
+++ b/src/test/java/org/grouplens/grapht/reflect/internal/ReflectionInjectionTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 import javax.inject.Provider;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 
@@ -93,7 +92,7 @@ public class ReflectionInjectionTest {
         Assert.assertSame(instance, r.getInstance(TypeC.class));
 
         DAGNode<Component, Dependency> resolvedRoot =
-                r.getSolver().getGraph().getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(rootDesire)).getTail();
+                r.getSolver().getGraph().getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(rootDesire)).getTail();
         assertThat(resolvedRoot.getOutgoingEdges(),
                    hasSize(5));
 
@@ -180,7 +179,7 @@ public class ReflectionInjectionTest {
         Assert.assertSame(instance, r.getInstance(TypeC.class));
 
         DAGNode<Component, Dependency> resolvedRoot =
-                r.getSolver().getGraph().getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(rootDesire)).getTail();
+                r.getSolver().getGraph().getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(rootDesire)).getTail();
         assertThat(resolvedRoot.getOutgoingEdges(),
                    hasSize(5));
         

--- a/src/test/java/org/grouplens/grapht/solver/DependencySolverTest.java
+++ b/src/test/java/org/grouplens/grapht/solver/DependencySolverTest.java
@@ -58,7 +58,7 @@ public class DependencySolverTest {
     
     // bypass synthetic root and return node that resolves the desire 
     private DAGNode<Component, Dependency> getRoot(DependencySolver r, Desire d) {
-        return r.getGraph().getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(d)).getTail();
+        return r.getGraph().getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(d)).getTail();
     }
     
     @Test
@@ -219,15 +219,16 @@ public class DependencySolverTest {
         DAGNode<Component, Dependency> n2 = getNode(r.getGraph(), Component.create(s2, CachePolicy.NO_PREFERENCE));
         DAGNode<Component, Dependency> n3 = getNode(r.getGraph(), Component.create(s3, CachePolicy.NO_PREFERENCE));
 
-        assertThat(Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))),
+        assertThat(Sets.filter(n1.getOutgoingEdges(),
+                               e -> e.getTail().equals(n2)),
                    hasSize(1));
-        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).iterator().next().getLabel().getInitialDesire());
         
-        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).size());
-        Assert.assertEquals(d2, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n3)).size());
+        Assert.assertEquals(d2, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n3)).iterator().next().getLabel().getInitialDesire());
         
-        Assert.assertEquals(1, Sets.filter(n2.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).size());
-        Assert.assertEquals(d2, Sets.filter(n2.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n2.getOutgoingEdges(), e -> e.getTail().equals(n3)).size());
+        Assert.assertEquals(d2, Sets.filter(n2.getOutgoingEdges(), e -> e.getTail().equals(n3)).iterator().next().getLabel().getInitialDesire());
     }
     
     @Test
@@ -281,15 +282,15 @@ public class DependencySolverTest {
         Assert.assertEquals(n1, rootNode);
         Assert.assertEquals(2, n1.getOutgoingEdges().size());
         
-        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).size());
-        Assert.assertEquals(dr1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).iterator().next().getLabel().getInitialDesire());
-        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).size());
-        Assert.assertEquals(dr2, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).size());
+        Assert.assertEquals(dr1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n3)).size());
+        Assert.assertEquals(dr2, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n3)).iterator().next().getLabel().getInitialDesire());
 
-        Assert.assertEquals(1, Sets.filter(n2.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n4))).size());
-        Assert.assertEquals(d3, Sets.filter(n2.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n4))).iterator().next().getLabel().getInitialDesire());
-        Assert.assertEquals(1, Sets.filter(n3.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(on4))).size());
-        Assert.assertEquals(d3, Sets.filter(n3.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(on4))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n2.getOutgoingEdges(), e -> e.getTail().equals(n4)).size());
+        Assert.assertEquals(d3, Sets.filter(n2.getOutgoingEdges(), e -> e.getTail().equals(n4)).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n3.getOutgoingEdges(), e -> e.getTail().equals(on4)).size());
+        Assert.assertEquals(d3, Sets.filter(n3.getOutgoingEdges(), e -> e.getTail().equals(on4)).iterator().next().getLabel().getInitialDesire());
     }
     
     @Test
@@ -365,11 +366,11 @@ public class DependencySolverTest {
         Assert.assertNotNull(n3);
         Assert.assertNull(on3);
         
-        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).size());
-        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).size());
+        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).iterator().next().getLabel().getInitialDesire());
 
-        Assert.assertEquals(1, Sets.filter(n2.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).size());
-        Assert.assertEquals(d2, Sets.filter(n2.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n2.getOutgoingEdges(), e -> e.getTail().equals(n3)).size());
+        Assert.assertEquals(d2, Sets.filter(n2.getOutgoingEdges(), e -> e.getTail().equals(n3)).iterator().next().getLabel().getInitialDesire());
     }
 
     @Test
@@ -419,11 +420,11 @@ public class DependencySolverTest {
         Assert.assertNotNull(n3);
         Assert.assertNull(on3);
         
-        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).size());
-        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).size());
+        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).iterator().next().getLabel().getInitialDesire());
 
-        Assert.assertEquals(1, Sets.filter(n2.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).size());
-        Assert.assertEquals(d2, Sets.filter(n2.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n2.getOutgoingEdges(), e -> e.getTail().equals(n3)).size());
+        Assert.assertEquals(d2, Sets.filter(n2.getOutgoingEdges(), e -> e.getTail().equals(n3)).iterator().next().getLabel().getInitialDesire());
     }
     
     @Test
@@ -462,8 +463,8 @@ public class DependencySolverTest {
         Assert.assertNotNull(n2);
         Assert.assertNull(on2);
         
-        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).size());
-        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).size());
+        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).iterator().next().getLabel().getInitialDesire());
     }
 
     @Test
@@ -501,14 +502,14 @@ public class DependencySolverTest {
         DAGNode<Component, Dependency> n2 = getNode(r.getGraph(), Component.create(sd2, CachePolicy.NO_PREFERENCE));
         DAGNode<Component, Dependency> n3 = getNode(r.getGraph(), Component.create(sd3, CachePolicy.NO_PREFERENCE));
         
-        Assert.assertEquals(1, Sets.filter(rootNode.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n1))).size());
-        Assert.assertEquals(d1, Sets.filter(rootNode.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n1))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(rootNode.getOutgoingEdges(), e -> e.getTail().equals(n1)).size());
+        Assert.assertEquals(d1, Sets.filter(rootNode.getOutgoingEdges(), e -> e.getTail().equals(n1)).iterator().next().getLabel().getInitialDesire());
         
-        Assert.assertEquals(1, Sets.filter(rootNode.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).size());
-        Assert.assertEquals(d2, Sets.filter(rootNode.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(rootNode.getOutgoingEdges(), e -> e.getTail().equals(n2)).size());
+        Assert.assertEquals(d2, Sets.filter(rootNode.getOutgoingEdges(), e -> e.getTail().equals(n2)).iterator().next().getLabel().getInitialDesire());
         
-        Assert.assertEquals(1, Sets.filter(rootNode.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).size());
-        Assert.assertEquals(d3, Sets.filter(rootNode.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(rootNode.getOutgoingEdges(), e -> e.getTail().equals(n3)).size());
+        Assert.assertEquals(d3, Sets.filter(rootNode.getOutgoingEdges(), e -> e.getTail().equals(n3)).iterator().next().getLabel().getInitialDesire());
     }
 
     @Test
@@ -582,11 +583,11 @@ public class DependencySolverTest {
         DAGNode<Component, Dependency> n2 = getNode(r.getGraph(), Component.create(s2, CachePolicy.NO_PREFERENCE));
         DAGNode<Component, Dependency> n3 = getNode(r.getGraph(), Component.create(s3, CachePolicy.NO_PREFERENCE));
         
-        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).size());
-        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).size());
+        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).iterator().next().getLabel().getInitialDesire());
         
-        Assert.assertEquals(1, Sets.filter(n2.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).size());
-        Assert.assertEquals(d2, Sets.filter(n2.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n3))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n2.getOutgoingEdges(), e -> e.getTail().equals(n3)).size());
+        Assert.assertEquals(d2, Sets.filter(n2.getOutgoingEdges(), e -> e.getTail().equals(n3)).iterator().next().getLabel().getInitialDesire());
     }
 
     @Test
@@ -813,8 +814,8 @@ public class DependencySolverTest {
         
         Assert.assertNotNull(n1);
         Assert.assertNotNull(n2);
-        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).size());
-        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).size());
+        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).iterator().next().getLabel().getInitialDesire());
     }
 
     @Test
@@ -847,8 +848,8 @@ public class DependencySolverTest {
         
         Assert.assertNotNull(n1);
         Assert.assertNotNull(n2);
-        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).size());
-        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(n2))).iterator().next().getLabel().getInitialDesire());
+        Assert.assertEquals(1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).size());
+        Assert.assertEquals(d1, Sets.filter(n1.getOutgoingEdges(), e -> e.getTail().equals(n2)).iterator().next().getLabel().getInitialDesire());
     }
     
     @Test
@@ -883,15 +884,15 @@ public class DependencySolverTest {
         Assert.assertEquals(2, root.getOutgoingEdges().size()); // da and dap
         
         DAGNode<Component, Dependency> na =
-                root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(da)).getTail();
-        DAGNode<Component, Dependency> nap = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(dap)).getTail();
+                root.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(da)).getTail();
+        DAGNode<Component, Dependency> nap = root.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(dap)).getTail();
         
         // sa and sap were different satisfactions, so they should be separate nodes
         Assert.assertNotSame(na, nap);
         
         // the resolved desire for a1, from da
-        DAGNode<Component, Dependency> ra1 = na.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
-        DAGNode<Component, Dependency> ra1p = nap.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
+        DAGNode<Component, Dependency> ra1 = na.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(a1)).getTail();
+        DAGNode<Component, Dependency> ra1p = nap.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(a1)).getTail();
         
         // verify that both a and ap point to the sb satisfaction, and verify
         // that sb (and also its children) are properly shared
@@ -899,10 +900,13 @@ public class DependencySolverTest {
         Assert.assertSame(sd, ra1p.getLabel().getSatisfaction());
         Assert.assertSame(ra1, ra1p);
 
-        Predicate<DAGNode<Component, ?>> tgt = DAGNode.labelMatches(Predicates.equalTo(Component.create(sd, CachePolicy.NO_PREFERENCE)));
         DAGNode<Component, Dependency> node =
-                Iterables.find(r.getGraph().getReachableNodes(),
-                               tgt);
+                r.getGraph()
+                 .getReachableNodes()
+                 .stream()
+                 .filter(e -> e.getLabel().equals(Component.create(sd, CachePolicy.NO_PREFERENCE)))
+                 .findFirst()
+                 .orElseThrow(() -> new AssertionError("could not find node"));
         assertThat(r.getGraph().getIncomingEdges(node),
                    hasSize(2));
     }
@@ -945,15 +949,15 @@ public class DependencySolverTest {
         Assert.assertEquals(8 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(2, root.getOutgoingEdges().size()); // da and dap
         
-        DAGNode<Component, Dependency> na = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(da)).getTail();
-        DAGNode<Component, Dependency> nap = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(dap)).getTail();
+        DAGNode<Component, Dependency> na = root.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(da)).getTail();
+        DAGNode<Component, Dependency> nap = root.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(dap)).getTail();
         
         // sa and sap were different satisfactions, so they should be separate nodes
         Assert.assertNotSame(na, nap);
         
         // the resolved desire for a1, from da
-        DAGNode<Component, Dependency> ra1 = na.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
-        DAGNode<Component, Dependency> ra1p = nap.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
+        DAGNode<Component, Dependency> ra1 = na.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(a1)).getTail();
+        DAGNode<Component, Dependency> ra1p = nap.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(a1)).getTail();
         
         // verify that both ra1 and ra1p are different nodes that both use the
         // sd satisfaction because sd's dependencies are configured differently
@@ -961,10 +965,10 @@ public class DependencySolverTest {
         Assert.assertSame(sd, ra1.getLabel().getSatisfaction());
         Assert.assertSame(sd, ra1p.getLabel().getSatisfaction());
         
-        Assert.assertSame(sb, ra1.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(d1)).getTail().getLabel().getSatisfaction());
-        Assert.assertSame(sc, ra1.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(d2)).getTail().getLabel().getSatisfaction());
-        Assert.assertSame(sbp, ra1p.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(d1)).getTail().getLabel().getSatisfaction());
-        Assert.assertSame(scp, ra1p.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(d2)).getTail().getLabel().getSatisfaction());
+        Assert.assertSame(sb, ra1.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(d1)).getTail().getLabel().getSatisfaction());
+        Assert.assertSame(sc, ra1.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(d2)).getTail().getLabel().getSatisfaction());
+        Assert.assertSame(sbp, ra1p.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(d1)).getTail().getLabel().getSatisfaction());
+        Assert.assertSame(scp, ra1p.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(d2)).getTail().getLabel().getSatisfaction());
     }
     
     @Test
@@ -996,12 +1000,12 @@ public class DependencySolverTest {
         Assert.assertEquals(4 + 1, r.getGraph().getReachableNodes().size()); // add one for synthetic root
         Assert.assertEquals(2, root.getOutgoingEdges().size()); // da and dd
         
-        DAGNode<Component, Dependency> na = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(da)).getTail();
-        DAGNode<Component, Dependency> nd = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(dd)).getTail();
+        DAGNode<Component, Dependency> na = root.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(da)).getTail();
+        DAGNode<Component, Dependency> nd = root.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(dd)).getTail();
         
         // additionally verify that there is an edge going from na to nd
-        Assert.assertEquals(1, Sets.filter(na.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(nd))).size());
-        Assert.assertSame(nd, na.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail());
+        Assert.assertEquals(1, Sets.filter(na.getOutgoingEdges(), e -> e.getTail().equals(nd)).size());
+        Assert.assertSame(nd, na.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(a1)).getTail());
     }
     
     @Test
@@ -1043,14 +1047,14 @@ public class DependencySolverTest {
         Assert.assertEquals(2, root.getOutgoingEdges().size()); // da and dd
         
         // resolved root desire nodes
-        DAGNode<Component, Dependency> na = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(da)).getTail();
-        DAGNode<Component, Dependency> nd = root.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(dd)).getTail();
+        DAGNode<Component, Dependency> na = root.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(da)).getTail();
+        DAGNode<Component, Dependency> nd = root.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(dd)).getTail();
         
         // make sure that there is no edge between na and nd
-        Assert.assertTrue(Sets.filter(na.getOutgoingEdges(), DAGEdge.tailMatches(Predicates.equalTo(nd))).isEmpty());
+        Assert.assertTrue(Sets.filter(na.getOutgoingEdges(), e -> e.getTail().equals(nd)).isEmpty());
         
         // look up dependency for na (which is also the sd satisfaction)
-        DAGNode<Component, Dependency> nad = na.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(a1)).getTail();
+        DAGNode<Component, Dependency> nad = na.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(a1)).getTail();
         
         // verify that the two sd nodes are different and have different edge
         // configurations
@@ -1058,10 +1062,10 @@ public class DependencySolverTest {
         Assert.assertSame(sd, nd.getLabel().getSatisfaction());
         Assert.assertSame(sd, nad.getLabel().getSatisfaction());
         
-        Assert.assertSame(sb, nad.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(d1)).getTail().getLabel().getSatisfaction());
-        Assert.assertSame(sc, nad.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(d2)).getTail().getLabel().getSatisfaction());
-        Assert.assertSame(sbp, nd.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(d1)).getTail().getLabel().getSatisfaction());
-        Assert.assertSame(scp, nd.getOutgoingEdgeWithLabel(Dependency.hasInitialDesire(d2)).getTail().getLabel().getSatisfaction());
+        Assert.assertSame(sb, nad.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(d1)).getTail().getLabel().getSatisfaction());
+        Assert.assertSame(sc, nad.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(d2)).getTail().getLabel().getSatisfaction());
+        Assert.assertSame(sbp, nd.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(d1)).getTail().getLabel().getSatisfaction());
+        Assert.assertSame(scp, nd.getOutgoingEdgeWithLabel(dep -> dep.hasInitialDesire(d2)).getTail().getLabel().getSatisfaction());
     }
 
     @Test(expected=UnresolvableDependencyException.class)
@@ -1193,8 +1197,11 @@ public class DependencySolverTest {
     }
     
     private DAGNode<Component, Dependency> getNode(DAGNode<Component, Dependency> g, Component s) {
-        Predicate<DAGNode<Component, ?>> pred = DAGNode.labelMatches(Predicates.equalTo(s));
-        return Iterables.find(g.getReachableNodes(), pred, null);
+        return g.getReachableNodes()
+                .stream()
+                .filter(e -> e.getLabel().equals(s))
+                .findFirst()
+                .orElse(null);
     }
     
     @Qualifier


### PR DESCRIPTION
This changes the DAG data structures to use Java 8 functional interfaces, and drops quite a few utility methods that were needed to make things work without lambdas. Lambdas are a more readable way to write code using DAG nodes.

LensKit will need to be updated for this PR.